### PR TITLE
workflows: add nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,20 @@
+name: Nightly
+
+env:
+  VERSION: ${{ format('nightly-{0}.{1}.{2}', 0, 0, github.run_number) }}
+
+on:
+  schedule:
+    - cron: "30 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  build-nightly:
+    name: Nightly
+    runs-on: ubuntu-latest
+    container:
+      image: hansbinderup/meson-gcc:1.0
+      options: --user root
+    steps:
+      - name: TODO
+        run: echo "This workflow is not yet implemented"


### PR DESCRIPTION
We have to declare a workflow dispatch prematurely to be able to test it.