### PR TITLE
workflows: implement nightly build/release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,20 +1,51 @@
 name: Nightly
 
+# NOTE: this job should only build a release if either:
+# 1. triggered manually (workflow_dispatch)
+# 2. there's changes the last 24hrs
+
 env:
-  VERSION: ${{ format('nightly-{0}.{1}.{2}', 0, 0, github.run_number) }}
+  VERSION: ${{ format('nightly-v{0}', github.run_number) }}
+  GITHUB_EVENT_NAME: ${{ github.event_name }}
 
 on:
   schedule:
-    - cron: "30 23 * * *"
+    - cron: "30 23 * * *" # run every day at 23:30
   workflow_dispatch:
 
 jobs:
-  build-nightly:
+  nightly:
     name: Nightly
     runs-on: ubuntu-latest
     container:
       image: hansbinderup/meson-gcc:1.0
       options: --user root
     steps:
-      - name: TODO
-        run: echo "This workflow is not yet implemented"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          clean: true
+      - name: Safe directory
+        run: git config --global --add safe.directory '*'
+      - name: Check for new commits
+        run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
+      - name: Build release
+        if: ${{ env.NEW_COMMIT_COUNT > 0 || github.event_name == 'workflow_dispatch' }}
+        run: scripts/create_release.sh
+      - name: Upload release
+        id: upload
+        uses: softprops/action-gh-release@v2
+        if: ${{ env.NEW_COMMIT_COUNT > 0 || github.event_name == 'workflow_dispatch' }}
+        with:
+          files: .release/*
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
+          generate_release_notes: true
+          target_commitish: ${{ github.ref }}
+          prerelease: true
+          draft: true
+      - name: Summary
+        if: ${{ env.NEW_COMMIT_COUNT > 0 || github.event_name == 'workflow_dispatch' }}
+        run: |
+          SUMMARY=$'# Nightly release can be found at: [${{ env.VERSION }}](${{ steps.upload.outputs.url }})'
+          echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
           clean: true
     - name: Safe directory
       run: git config --global --add safe.directory '*'
-    - name: Build release
+    - name: Build Meltdown
       run: scripts/build.sh
 
   unit-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
 compile_commands.json
+.release

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ Comments:
     * For release/optimized build: `./scripts/build.sh -r` (-r is optional and will run the compiled executable)
     * For debugging in gdb: `./scripts/debug.sh`
     * Compile and run unit-tests: `./scripts/unit_test.sh`
+
+## Nightly builds
+
+Every night at 23:30 a nightly build will be triggered by the github actions scheduler.
+This build will be untagged (pre-release draft) to not polute actual releases.
+
+A test server will scan for nightly builds and pick them up when they notice that a new one has been built.
+The server will then run matchmaking on Lichess to test the engine's current state.
+
+A manual nightly build can also be triggered using the [workflow's dispatch](https://github.com/hansbinderup/meltdown-chess-engine/actions/workflows/nightly.yml).

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,3 +3,5 @@
 rm -rf .build
 rm -rf .build-tests
 rm -rf .debug
+rm -rf .build-release
+rm -rf .release

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+# This script expects these env variables to be set:
+#   VERSION (release prefix)
+
+echo "New commits in last 24 hours: $NEW_COMMIT_COUNT"
+if [[ "$NEW_COMMIT_COUNT" -eq 0 ]]; then
+    # skip the build if no new commits and if the build was triggered by the scheduler
+    # NOTE: we should always allow builds to be triggered manually, so only skip automated ones
+    if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+        echo "No new commits. Skipping workflow."
+        exit 0 # exit quietly - we don't want the job to look like it's "failed"
+    fi
+fi
+
+BUILD_DIR=".build-release"
+RELEASE_DIR=".release"
+
+# ensure that we always have an empty release folder
+rm -rf $RELEASE_DIR || true
+mkdir $RELEASE_DIR
+
+# NOTE: we always want a clean build when building a release
+meson setup "$BUILD_DIR" --wipe --buildtype=release -Dmeltdown-version=$VERSION
+meson compile -C "$BUILD_DIR"
+
+# no need to store "chess engine" in our release name - rename and append version
+cp "$BUILD_DIR/meltdown-chess-engine" "$RELEASE_DIR/meltdown-$VERSION"
+
+# add all release files to a tar ball - will be useful when we have multiple executables
+pushd $RELEASE_DIR
+tar -czvf meltdown-$VERSION.tar.gz *
+popd


### PR DESCRIPTION
This commit adds a script to build and pack a release. Also it adds a github workflow to trigger a nightly build; both scheduled automatically but also from a workflow dispatch.

The nightly releases will be tagged as prerelease drafts meaning that they will not polute the "real" releases.

NOTE: this will add the option to decide which branch to build a nightly from. This is a design choice as it will be quite handy to build a nightly from a feature branch etc. Also, it will allow the auto deploy (WIP) to fallback to "regular nightly" after a given period; perfect for testing!

TODO: easy way to turn it on/off if we want a more longterm test done eg.