### PR TITLE
fmt: static link

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ magic_enum = subproject('magic_enum', default_options: ['test=false'])
 magic_enum_dep = magic_enum.get_variable('magic_enum_dep')
 
 # fmt
-fmt = subproject('fmt')
+fmt = subproject('fmt', default_options: ['default_library=static'])
 fmt_dep = fmt.get_variable('fmt_dep')
 
 meltdown_dep = declare_dependency(include_directories: 'src', dependencies: [magic_enum_dep, fmt_dep])


### PR DESCRIPTION
Static linking will bundle the fmt library in our executable. This is faster and more scalable than expecting dynamic linking for our users.