### PR TITLE
meson: add ci build arch generalization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,14 +4,11 @@ project('meltdown-chess-engine', 'cpp',
   default_options: ['warning_level=3', 'cpp_std=c++26'])
 
 subdir('version')
+subdir('targets')
 
 # set these values as high as possible - required to compile the magic tables
 add_project_arguments('-fconstexpr-loop-limit=2147483647', language: 'cpp')
 add_project_arguments('-fconstexpr-ops-limit=100000000000', language: 'cpp')
-
-# default compile with native cpu instructions
-# TODO: make an option to allow for better cross compilation
-add_project_arguments('-march=native', language: 'cpp')
 
 if get_option('buildtype') != 'debug'
   add_project_arguments('-funroll-loops', '-m64', '-finline-functions',  language : 'cpp')

--- a/meson.options
+++ b/meson.options
@@ -1,2 +1,3 @@
 option('unit-tests', type: 'boolean', value: false, description: 'Build the unit tests')
+option('ci', type: 'boolean', value: false, description: 'Build is from the CI')
 option('meltdown-version', type: 'string', value: '0.0.0-dev', description: 'Meltdown version')

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -23,7 +23,7 @@ rm -rf $RELEASE_DIR || true
 mkdir $RELEASE_DIR
 
 # NOTE: we always want a clean build when building a release
-meson setup "$BUILD_DIR" --wipe --buildtype=release -Dmeltdown-version=$VERSION
+meson setup "$BUILD_DIR" --wipe --buildtype=release -Dmeltdown-version=$VERSION -Dci=true
 meson compile -C "$BUILD_DIR"
 
 # no need to store "chess engine" in our release name - rename and append version

--- a/targets/meson.build
+++ b/targets/meson.build
@@ -1,0 +1,8 @@
+# TODO: this is very primitive. Add support for more build targets
+if get_option('ci')
+  # very generic setup - should fit almost all CPUs out there
+  add_project_arguments('-march=x86-64-v2', '-Ofast', language: 'cpp')
+else
+  # local build - try to optimize locally
+  add_project_arguments('-march=native', '-Ofast', language: 'cpp')
+endif


### PR DESCRIPTION
When building on the CI it would run with march=native. This meant that the build was optimized for the server building it and not in general optimized for most x86 cpus.

Using the x86-v2 we can build for almost every CPU out there. And it should also be optimized way further.