### PR TITLE
static_evaluation: improve tapered score + add some new positional bonuses / game phase bonuses

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -2,10 +2,10 @@
 
 #include "engine/move_handling.h"
 #include "engine/tt_hash_table.h"
-#include "evaluation/material_scoring.h"
 #include "evaluation/move_ordering.h"
 #include "evaluation/pv_table.h"
 #include "evaluation/repetition.h"
+#include "evaluation/static_evaluation.h"
 #include "fmt/ranges.h"
 #include "movegen/move_types.h"
 #include <atomic>
@@ -87,8 +87,8 @@ public:
         fmt::println("\nTotal nodes:     {}\n"
                      "Search score:    {}\n"
                      "PV-line:         {}\n"
-                     "Material score:  {}\n",
-            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), materialScore(board));
+                     "Static eval:     {}\n",
+            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), staticEvaluation(board));
     }
 
     void setWhiteTime(uint64_t time)
@@ -300,7 +300,7 @@ private:
 
         // Engine is not designed to search deeper than this! Make sure to stop before it's too late
         if (m_ply >= s_maxSearchDepth) {
-            return materialScore(board);
+            return staticEvaluation(board);
         }
 
         m_moveOrdering.pvTable().updateLength(m_ply);
@@ -424,7 +424,7 @@ private:
         m_nodes++;
         m_selDepth = std::max(m_selDepth, m_ply);
 
-        const int32_t evaluation = materialScore(board);
+        const int32_t evaluation = staticEvaluation(board);
 
         if (m_ply >= s_maxSearchDepth)
             return evaluation;

--- a/src/evaluation/game_phase.h
+++ b/src/evaluation/game_phase.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "board_defs.h"
+#include "magic_enum/magic_enum.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace evaluation::gamephase {
+
+namespace {
+
+constexpr uint8_t s_mgLimit { 24 };
+
+struct Weight {
+    uint8_t mg;
+    uint8_t eg;
+};
+
+[[nodiscard]] constexpr Weight computeWeight(uint8_t materialPhase)
+{
+    /* we have to limit the score in case of early promotions */
+    const uint8_t mgPhase = std::min(materialPhase, s_mgLimit);
+    const uint8_t egPhase = s_mgLimit - mgPhase;
+
+    return { mgPhase, egPhase };
+}
+
+}
+
+constexpr std::array<uint8_t, magic_enum::enum_count<Piece>()> s_materialPhaseScore = {
+    0, 1, 1, 2, 4, 0, /* white pieces */
+    0, 1, 1, 2, 4, 0 /* black pieces */
+};
+
+enum Phases : uint8_t {
+    GamePhaseMg = 0,
+    GamePhaseEg,
+};
+
+struct Score {
+    int32_t mg {};
+    int32_t eg {};
+    uint8_t materialScore {};
+
+    constexpr Score operator+(const Score& other) const noexcept
+    {
+        return { static_cast<int32_t>(mg + other.mg), static_cast<int32_t>(eg + other.eg), static_cast<uint8_t>(materialScore + other.materialScore) };
+    }
+
+    constexpr Score& operator+=(const Score& other) noexcept
+    {
+        mg += other.mg;
+        eg += other.eg;
+        materialScore += other.materialScore;
+        return *this;
+    }
+
+    /* NOTE: material score should still be incremented here! */
+    constexpr Score operator-(const Score& other) const noexcept
+    {
+        return { static_cast<int32_t>(mg - other.mg), static_cast<int32_t>(eg - other.eg), static_cast<uint8_t>(materialScore + other.materialScore) };
+    }
+
+    /* NOTE: material score should still be incremented here! */
+    constexpr Score& operator-=(const Score& other) noexcept
+    {
+        mg -= other.mg;
+        eg -= other.eg;
+        materialScore += other.materialScore;
+        return *this;
+    }
+};
+
+[[nodiscard]] constexpr int32_t taperedScore(const Score& score)
+{
+    const auto weight = computeWeight(score.materialScore);
+    return (score.mg * weight.mg + score.eg * weight.eg) / s_mgLimit;
+}
+
+}
+

--- a/src/evaluation/pesto_tables.h
+++ b/src/evaluation/pesto_tables.h
@@ -2,6 +2,7 @@
 
 #include "bit_board.h"
 #include "board_defs.h"
+#include "evaluation/game_phase.h"
 #include "helpers/bit_operations.h"
 #include "magic_enum/magic_enum.hpp"
 #include <array>
@@ -345,41 +346,7 @@ constexpr auto generatePestoTable()
 }
 }
 
-constexpr std::array<uint8_t, magic_enum::enum_count<Piece>()> s_gamePhaseScore = {
-    0, 1, 1, 2, 4, 0, /* white pieces */
-    0, 1, 1, 2, 4, 0 /* black pieces */
-};
-
 constexpr auto s_mgTables = mg::generatePestoTable();
 constexpr auto s_egTables = eg::generatePestoTable();
-
-constexpr int32_t evaluate(const BitBoard& board)
-{
-    int32_t mgScore {};
-    int32_t egScore {};
-    uint8_t gamePhase {};
-
-    for (uint8_t wp = WhitePawn; wp <= WhiteKing; wp++) {
-        helper::bitIterate(board.pieces[wp], [&mgScore, &egScore, &gamePhase, wp](BoardPosition pos) {
-            mgScore += s_mgTables[wp][pos];
-            egScore += s_egTables[wp][pos];
-            gamePhase += s_gamePhaseScore[wp];
-        });
-    }
-
-    for (uint8_t bp = BlackPawn; bp <= BlackKing; bp++) {
-        helper::bitIterate(board.pieces[bp], [&mgScore, &egScore, &gamePhase, bp](BoardPosition pos) {
-            mgScore -= s_mgTables[bp][pos];
-            egScore -= s_egTables[bp][pos];
-            gamePhase += s_gamePhaseScore[bp];
-        });
-    }
-
-    constexpr uint8_t mgLimit { 24 };
-    const uint8_t mgGamePhase = std::min(gamePhase, mgLimit); /* 'min' in case of early promotion */
-    const uint8_t egGamePhase = mgLimit - mgGamePhase;
-
-    return (mgScore * mgGamePhase + egScore * egGamePhase) / mgLimit;
-}
 
 }

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -5,6 +5,8 @@
 #include <array>
 #include <cstdint>
 
+#include "evaluation/game_phase.h"
+#include "evaluation/pesto_tables.h"
 #include "evaluation/position_tables.h"
 #include "helpers/bit_operations.h"
 #include "movegen/bishops.h"
@@ -15,126 +17,224 @@ namespace evaluation {
 
 namespace {
 
-constexpr int32_t s_doublePawnPenalty { -10 };
-constexpr int32_t s_isolatedPawnPenalty { -10 };
-constexpr auto s_passedPawnBonus = std::to_array<int32_t>({ 0, 10, 30, 50, 75, 100, 150, 200 });
-constexpr int32_t s_semiOpenFileScore { 10 };
-constexpr int32_t s_openFileScore { 15 };
+/* TODO: tune these parameters */
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_doublePawnPenalty { -10, -10 };
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_isolatedPawnPenalty { -10, -10 };
 
-constexpr int32_t s_bishopMobilityScore { 3 };
-constexpr int32_t s_queenMobilityScore { 1 }; /* TODO: make game phase dependent */
-constexpr int32_t s_kingShieldScore { 5 };
+using PassedPawnType = std::array<int32_t, 8>;
+constexpr std::array<PassedPawnType, magic_enum::enum_count<gamephase::Phases>()> s_passedPawnBonus { {
+    { 0, 10, 30, 50, 75, 100, 150, 200 },
+    { 0, 10, 30, 50, 75, 100, 150, 200 },
+} };
+
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_semiOpenFileScore { 15, 15 };
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_openFileScore { 15, 15 };
+
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_bishopMobilityScore { 3, 3 };
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_queenMobilityScore { 1, 1 };
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_kingShieldScore { 5, 5 };
 
 }
 
 namespace position {
 
 template<Player player>
-constexpr static inline int32_t getPawnScore(const BitBoard& board, const uint64_t pawns)
+constexpr static inline gamephase::Score getPawnScore(const BitBoard& board, const uint64_t pawns)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
     helper::bitIterate(pawns, [&](BoardPosition pos) {
         const auto doubledPawns = std::popcount(pawns & s_fileMaskTable[pos]);
-        if (doubledPawns > 1)
-            score += doubledPawns * s_doublePawnPenalty;
+        if (doubledPawns > 1) {
+            score.mg += s_doublePawnPenalty[gamephase::GamePhaseMg];
+            score.eg += s_doublePawnPenalty[gamephase::GamePhaseEg];
+        }
 
-        if ((pawns & s_isolationMaskTable[pos]) == 0)
-            score += s_isolatedPawnPenalty;
+        if ((pawns & s_isolationMaskTable[pos]) == 0) {
+            score.mg += s_isolatedPawnPenalty[gamephase::GamePhaseMg];
+            score.eg += s_isolatedPawnPenalty[gamephase::GamePhaseEg];
+        }
 
         if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhitePawn];
+            score.mg += pesto::s_mgTables[WhitePawn][pos];
+            score.eg += pesto::s_egTables[WhitePawn][pos];
+
             if ((board.pieces[BlackPawn] & s_whitePassedPawnMaskTable[pos]) == 0) {
                 const uint8_t row = (pos / 8);
-                score += s_passedPawnBonus[row];
+                score.mg += s_passedPawnBonus[gamephase::GamePhaseMg][row];
+                score.eg += s_passedPawnBonus[gamephase::GamePhaseEg][row];
             }
         } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackPawn];
+            score.mg += pesto::s_mgTables[BlackPawn][pos];
+            score.eg += pesto::s_egTables[BlackPawn][pos];
+
             if ((board.pieces[WhitePawn] & s_blackPassedPawnMaskTable[pos]) == 0) {
                 const uint8_t row = (pos / 8);
-                score += s_passedPawnBonus[7 - row]; /* invert table for black */
+                score.mg += s_passedPawnBonus[gamephase::GamePhaseMg][7 - row];
+                score.eg += s_passedPawnBonus[gamephase::GamePhaseEg][7 - row];
             }
         }
-    });
-
-    return score;
-}
-
-constexpr static inline int32_t getBishopScore(const BitBoard& board, const uint64_t bishops)
-{
-    int32_t score = 0;
-
-    helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
-        const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);
-        score += std::popcount(moves) * s_bishopMobilityScore;
     });
 
     return score;
 }
 
 template<Player player>
-constexpr static inline int32_t getRookScore(const BitBoard& board, const uint64_t rooks)
+constexpr static inline gamephase::Score getKnightScore(const uint64_t knights)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
-    const uint64_t whitePawns = board.pieces[WhitePawn];
-    const uint64_t blackPawns = board.pieces[BlackPawn];
-
-    helper::bitIterate(rooks, [&](BoardPosition pos) {
-        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0)
-            score += s_openFileScore;
-
+    helper::bitIterate(knights, [&score](BoardPosition pos) {
         if constexpr (player == PlayerWhite) {
-            if ((whitePawns & s_fileMaskTable[pos]) == 0)
-                score += s_semiOpenFileScore;
-
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteKnight];
+            score.mg += pesto::s_mgTables[WhiteKnight][pos];
+            score.eg += pesto::s_egTables[WhiteKnight][pos];
         } else {
-            if ((blackPawns & s_fileMaskTable[pos]) == 0)
-                score += s_semiOpenFileScore;
+            score.materialScore += gamephase::s_materialPhaseScore[BlackKnight];
+            score.mg += pesto::s_mgTables[BlackKnight][pos];
+            score.eg += pesto::s_egTables[BlackKnight][pos];
         }
     });
 
     return score;
 }
 
-constexpr static inline int32_t getQueenScore(const BitBoard& board, const uint64_t queens)
+template<Player player>
+constexpr static inline gamephase::Score getBishopScore(const BitBoard& board, const uint64_t bishops)
 {
-    int32_t score = 0;
+    gamephase::Score score;
+
+    helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
+        const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);
+        const int count = std::popcount(moves);
+
+        score.mg += count * s_bishopMobilityScore[gamephase::GamePhaseMg];
+        score.eg += count * s_bishopMobilityScore[gamephase::GamePhaseEg];
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteBishop];
+            score.mg += pesto::s_mgTables[WhiteBishop][pos];
+            score.eg += pesto::s_egTables[WhiteBishop][pos];
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackBishop];
+            score.mg += pesto::s_mgTables[BlackBishop][pos];
+            score.eg += pesto::s_egTables[BlackBishop][pos];
+        }
+    });
+
+    return score;
+}
+
+template<Player player>
+constexpr gamephase::Score getRookScore(const BitBoard& board, const uint64_t rooks)
+{
+    gamephase::Score score;
+
+    const uint64_t whitePawns = board.pieces[WhitePawn];
+    const uint64_t blackPawns = board.pieces[BlackPawn];
+
+    helper::bitIterate(rooks, [&](BoardPosition pos) {
+        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0) {
+            score.mg += s_openFileScore[gamephase::GamePhaseMg];
+            score.eg += s_openFileScore[gamephase::GamePhaseEg];
+        }
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteRook];
+            score.mg += pesto::s_mgTables[WhiteRook][pos];
+            score.eg += pesto::s_egTables[WhiteRook][pos];
+
+            if ((whitePawns & s_fileMaskTable[pos]) == 0) {
+                score.mg += s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg += s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackRook];
+            score.mg += pesto::s_mgTables[BlackRook][pos];
+            score.eg += pesto::s_egTables[BlackRook][pos];
+
+            if ((blackPawns & s_fileMaskTable[pos]) == 0) {
+                score.mg += s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg += s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
+        }
+    });
+
+    return score;
+}
+
+template<Player player>
+constexpr static inline gamephase::Score getQueenScore(const BitBoard& board, const uint64_t queens)
+{
+    gamephase::Score score;
 
     helper::bitIterate(queens, [&board, &score](BoardPosition pos) {
         const uint64_t moves
             = movegen::getBishopMoves(pos, board.occupation[Both])
             | movegen::getRookMoves(pos, board.occupation[Both]);
 
-        score += std::popcount(moves) * s_queenMobilityScore;
+        const int count = std::popcount(moves);
+
+        score.mg += count * s_queenMobilityScore[gamephase::GamePhaseMg];
+        score.eg += count * s_queenMobilityScore[gamephase::GamePhaseEg];
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteQueen];
+            score.mg += pesto::s_mgTables[WhiteQueen][pos];
+            score.eg += pesto::s_egTables[WhiteQueen][pos];
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackQueen];
+            score.mg += pesto::s_mgTables[BlackQueen][pos];
+            score.eg += pesto::s_egTables[BlackQueen][pos];
+        }
     });
 
     return score;
 }
 
 template<Player player>
-constexpr static inline int32_t getKingScore(const BitBoard& board, const uint64_t king)
+constexpr static inline gamephase::Score getKingScore(const BitBoard& board, const uint64_t king)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
     const uint64_t whitePawns = board.pieces[WhitePawn];
     const uint64_t blackPawns = board.pieces[BlackPawn];
 
     helper::bitIterate(king, [&](BoardPosition pos) {
         /* king will get a penalty for semi/open files */
-        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0)
-            score -= s_openFileScore;
+        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0) {
+            score.mg -= s_openFileScore[gamephase::GamePhaseMg];
+            score.eg -= s_openFileScore[gamephase::GamePhaseEg];
+        }
 
         if constexpr (player == PlayerWhite) {
-            if ((whitePawns & s_fileMaskTable[pos]) == 0)
-                score -= s_semiOpenFileScore;
+            score.mg += pesto::s_mgTables[WhiteKing][pos];
+            score.eg += pesto::s_egTables[WhiteKing][pos];
+
+            if ((whitePawns & s_fileMaskTable[pos]) == 0) {
+                score.mg -= s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg -= s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
 
             const uint64_t kingShields = movegen::getKingMoves(pos) & board.occupation[PlayerWhite];
-            score += std::popcount(kingShields) * s_kingShieldScore;
+            const int shieldCount = std::popcount(kingShields);
+            score.mg += shieldCount * s_kingShieldScore[gamephase::GamePhaseMg];
+            score.eg += shieldCount * s_kingShieldScore[gamephase::GamePhaseEg];
         } else {
-            if ((blackPawns & s_fileMaskTable[pos]) == 0)
-                score -= s_semiOpenFileScore;
+            score.mg += pesto::s_mgTables[BlackKing][pos];
+            score.eg += pesto::s_egTables[BlackKing][pos];
+
+            if ((blackPawns & s_fileMaskTable[pos]) == 0) {
+                score.mg -= s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg -= s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
 
             const uint64_t kingShields = movegen::getKingMoves(pos) & board.occupation[PlayerBlack];
-            score += std::popcount(kingShields) * s_kingShieldScore;
+            const int shieldCount = std::popcount(kingShields);
+            score.mg += shieldCount * s_kingShieldScore[gamephase::GamePhaseMg];
+            score.eg += shieldCount * s_kingShieldScore[gamephase::GamePhaseEg];
         }
     });
 

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -31,8 +31,10 @@ constexpr std::array<PassedPawnType, magic_enum::enum_count<gamephase::Phases>()
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_semiOpenFileScore { 10, 15 };
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_openFileScore { 15, 30 };
 
-constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_knightMobilityScore { 2, 3 };
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_bishopMobilityScore { 3, 5 };
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_bishopPairScore { 30, 50 };
+
+constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_knightMobilityScore { 2, 3 };
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_rookMobilityScore { 2, 4 };
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_queenMobilityScore { 1, 2 };
 constexpr std::array<int32_t, magic_enum::enum_count<gamephase::Phases>()> s_kingShieldScore { 10, 5 };
@@ -114,6 +116,12 @@ template<Player player>
 constexpr static inline gamephase::Score getBishopScore(const BitBoard& board, const uint64_t bishops)
 {
     gamephase::Score score;
+
+    const int amntBishops = std::popcount(bishops);
+    if (amntBishops >= 2) {
+        score.mg += s_bishopPairScore[gamephase::GamePhaseMg];
+        score.mg += s_bishopPairScore[gamephase::GamePhaseEg];
+    }
 
     helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
         const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);

--- a/src/evaluation/static_evaluation.h
+++ b/src/evaluation/static_evaluation.h
@@ -14,7 +14,7 @@
 
 namespace evaluation {
 
-constexpr int32_t materialScore(const BitBoard& board)
+constexpr int32_t staticEvaluation(const BitBoard& board)
 {
     /* we first evaluate based on "pesto score"
      * then we add mobility, double pawn etc. */

--- a/src/evaluation/static_evaluation.h
+++ b/src/evaluation/static_evaluation.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "bit_board.h"
-#include "evaluation/pesto_tables.h"
 #include "evaluation/positioning.h"
 
 #include <cstdint>
@@ -16,9 +15,7 @@ namespace evaluation {
 
 constexpr int32_t staticEvaluation(const BitBoard& board)
 {
-    /* we first evaluate based on "pesto score"
-     * then we add mobility, double pawn etc. */
-    int32_t score = pesto::evaluate(board);
+    gamephase::Score score;
 
     // Material scoring
     for (const auto piece : magic_enum::enum_values<Piece>()) {
@@ -27,15 +24,16 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
             score += position::getPawnScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteKnight:
+            score += position::getKnightScore<PlayerWhite>(board.pieces[piece]);
             break;
         case WhiteBishop:
-            score += position::getBishopScore(board, board.pieces[piece]);
+            score += position::getBishopScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteRook:
             score += position::getRookScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteQueen:
-            score += position::getQueenScore(board, board.pieces[piece]);
+            score += position::getQueenScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteKing:
             score += position::getKingScore<PlayerWhite>(board, board.pieces[piece]);
@@ -47,15 +45,16 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
             score -= position::getPawnScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackKnight:
+            score -= position::getKnightScore<PlayerBlack>(board.pieces[piece]);
             break;
         case BlackBishop:
-            score -= position::getBishopScore(board, board.pieces[piece]);
+            score -= position::getBishopScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackRook:
             score -= position::getRookScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackQueen:
-            score -= position::getQueenScore(board, board.pieces[piece]);
+            score -= position::getQueenScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackKing:
             score -= position::getKingScore<PlayerBlack>(board, board.pieces[piece]);
@@ -63,7 +62,8 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
         }
     }
 
-    return board.player == PlayerWhite ? score : -score;
+    const int32_t evaluation = gamephase::taperedScore(score);
+    return board.player == PlayerWhite ? evaluation : -evaluation;
 }
 
 }

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -1,4 +1,4 @@
-#include "evaluation/material_scoring.h"
+#include "evaluation/static_evaluation.h"
 #include "parsing/fen_parser.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -20,7 +20,7 @@ TEST_CASE("Scoring", "[scoring]")
             boardB.reset();
             boardB.player = PlayerBlack; /* flip side */
 
-            REQUIRE(evaluation::materialScore(boardW) == evaluation::materialScore(boardB));
+            REQUIRE(evaluation::staticEvaluation(boardW) == evaluation::staticEvaluation(boardB));
         }
 
         SECTION("Position 1")
@@ -31,7 +31,7 @@ TEST_CASE("Scoring", "[scoring]")
             REQUIRE(boardW.has_value());
             REQUIRE(boardB.has_value());
 
-            REQUIRE(evaluation::materialScore(*boardW) == evaluation::materialScore(*boardB));
+            REQUIRE(evaluation::staticEvaluation(*boardW) == evaluation::staticEvaluation(*boardB));
         }
     }
 


### PR DESCRIPTION
See each commit for details.

Let me know if the whole game phase stuff is too twisted @clarashepherd. 
I thought it's nice that all our scoring functions consider both mg and eg. Then it's easier to assign an actual meaningful score and do that consistently.