### PR TITLE
tests: add cutechess tournament tests

### DIFF
--- a/tests/cute-chess/.gitignore
+++ b/tests/cute-chess/.gitignore
@@ -1,0 +1,2 @@
+outputs
+config.json

--- a/tests/cute-chess/README.md
+++ b/tests/cute-chess/README.md
@@ -1,0 +1,11 @@
+## Cutechess tournament tests
+
+Copy the `config.json.example` to `config.json` and setup the engines you wanna test against each
+other.
+The results are printed to files in the `outputs` directory.
+
+To run the tests call `run-tournament.sh`. NOTE: it can be called from any location.
+
+The script will setup a tournament against the two specified engines. It will run random openings from the provided opening book.
+Each opening will be played twice (once from each side).
+It is possible to add SPRT; both enabling and configuring.

--- a/tests/cute-chess/config.json.example
+++ b/tests/cute-chess/config.json.example
@@ -1,0 +1,27 @@
+{
+    "new_engine": {
+        "name": "Engine to be tested",
+        "path": "/absolute/path/to/engine"
+    },
+    "baseline_engine": {
+        "name": "Engine to test against",
+        "path": "/absolute/path/to/engine"
+    },
+    "tournament": {
+        "rounds": 100,
+        "concurrency": 8,
+        "time_control": "0/8+0.08",
+        "opening_book": "tests/books/8moves_v3.pgn",
+        "opening_book_moves": 8,
+        "resign_move_count": 5,
+        "resign_score": 1000
+    },
+    "sprt": {
+        "enabled": true,
+        "elo_0_hypothesis": 0,
+        "elo_1_hypothesis": 20,
+        "alpha": 0.05,
+        "beta": 0.05
+    }
+}
+

--- a/tests/cute-chess/run-tournament.sh
+++ b/tests/cute-chess/run-tournament.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Get relative path from caller
+SOURCE_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+
+# Load configuration from JSON
+CONFIG_FILE="$SOURCE_DIR/config.json"
+
+# Output files
+OUTPUT_DIR="$SOURCE_DIR/outputs"
+mkdir -p "$OUTPUT_DIR"
+FILENAME_SUFFIX="$(date +"%d%m%Y-%H%M%S")"
+RESULT_OUTPUT="$OUTPUT_DIR/results_$FILENAME_SUFFIX.txt"
+PGN_OUTPUT="$OUTPUT_DIR/games_$FILENAME_SUFFIX.pgn"
+
+# engine settings
+ENGINE1_NAME=$(jq -r '.new_engine.name' "$CONFIG_FILE")
+ENGINE1_PATH=$(jq -r '.new_engine.path' "$CONFIG_FILE")
+
+ENGINE2_NAME=$(jq -r '.baseline_engine.name' "$CONFIG_FILE")
+ENGINE2_PATH=$(jq -r '.baseline_engine.path' "$CONFIG_FILE")
+
+# tournament settings
+ROUNDS=$(jq -r '.tournament.rounds' "$CONFIG_FILE")
+OPENING_BOOK=$(jq -r '.tournament.opening_book' "$CONFIG_FILE")
+OPENING_BOOK_MOVES=$(jq -r '.tournament.opening_book_moves' "$CONFIG_FILE")
+CONCURRENCY=$(jq -r '.tournament.concurrency' "$CONFIG_FILE")
+TIME_CONTROL=$(jq -r '.tournament.time_control' "$CONFIG_FILE")
+RESIGN_MOVES=$(jq -r '.tournament.resign_move_count' "$CONFIG_FILE")
+RESIGN_SCORE=$(jq -r '.tournament.resign_score' "$CONFIG_FILE")
+
+# sprt settings
+SPRT_STRING=""
+SPRT_ENABLED=$(jq -r '.sprt.enabled' "$CONFIG_FILE")
+if [[ "$SPRT_ENABLED" == "true" ]]; then
+    SPRT_ELO1=$(jq -r '.sprt.elo_0_hypothesis' "$CONFIG_FILE")
+    SPRT_ELO2=$(jq -r '.sprt.elo_1_hypothesis' "$CONFIG_FILE")
+    SPRT_ALPHA=$(jq -r '.sprt.alpha' "$CONFIG_FILE")
+    SPRT_BETA=$(jq -r '.sprt.beta' "$CONFIG_FILE")
+
+    SPRT_STRING="-event sprt-test -sprt elo0=$SPRT_ELO1 elo1=$SPRT_ELO2 alpha=$SPRT_ALPHA beta=$SPRT_BETA"
+fi
+
+echo "Running tournament $ENGINE1_NAME VS $ENGINE2_NAME - SPRT enabled: $SPRT_ENABLED"
+echo "Games: $ROUNDS, Opening book: $OPENING_BOOK, Time Control: $TIME_CONTROL"
+echo "<ctrl-c> will stop tests early"
+
+# Run the tournament
+cutechess-cli \
+  -engine cmd="$ENGINE1_PATH" name="$ENGINE1_NAME" $ENGINE1_OPTIONS \
+  -engine cmd="$ENGINE2_PATH" name="$ENGINE2_NAME" $ENGINE2_OPTIONS \
+  -each tc=$TIME_CONTROL proto=uci \
+  -concurrency $CONCURRENCY -rounds $ROUNDS -repeat -games 2 \
+  $SPRT_STRING \
+  -openings file=$OPENING_BOOK plies=$OPENING_BOOK_MOVES order=random policy=round \
+  -ratinginterval 5 -pgnout "$PGN_OUTPUT" -resign movecount=$RESIGN_MOVES score=$RESIGN_SCORE -maxmoves 200 \
+  -resultformat default > $RESULT_OUTPUT
+
+echo "Tournament finished!"
+echo "Results saved in $RESULT_OUTPUT"
+echo "Games saved in $PGN_OUTPUT"
+


### PR DESCRIPTION
This commit adds a new way of testing the engine.
It will run games with a given config and evaluate the performance between the two engines.

It is possible to setup the amount of games, if the test should run SPRT etc.
More info is added to the README.md.