### PR TITLE
static_evaluation: add extended tapered evaluation + performance improvements

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -2,10 +2,10 @@
 
 #include "engine/move_handling.h"
 #include "engine/tt_hash_table.h"
-#include "evaluation/material_scoring.h"
 #include "evaluation/move_ordering.h"
 #include "evaluation/pv_table.h"
 #include "evaluation/repetition.h"
+#include "evaluation/static_evaluation.h"
 #include "fmt/ranges.h"
 #include "movegen/move_types.h"
 #include "syzygy/syzygy.h"
@@ -91,8 +91,8 @@ public:
         fmt::println("\nTotal nodes:     {}\n"
                      "Search score:    {}\n"
                      "PV-line:         {}\n"
-                     "Material score:  {}\n",
-            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), materialScore(board));
+                     "Static eval:     {}\n",
+            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), staticEvaluation(board));
     }
 
     void setWhiteTime(uint64_t time)
@@ -313,7 +313,7 @@ private:
 
         // Engine is not designed to search deeper than this! Make sure to stop before it's too late
         if (m_ply >= s_maxSearchDepth) {
-            return materialScore(board);
+            return staticEvaluation(board);
         }
 
         m_moveOrdering.pvTable().updateLength(m_ply);
@@ -454,7 +454,7 @@ private:
         m_nodes++;
         m_selDepth = std::max(m_selDepth, m_ply);
 
-        const int32_t evaluation = materialScore(board);
+        const int32_t evaluation = staticEvaluation(board);
 
         if (m_ply >= s_maxSearchDepth)
             return evaluation;

--- a/src/evaluation/game_phase.h
+++ b/src/evaluation/game_phase.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "board_defs.h"
+#include "magic_enum/magic_enum.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace evaluation::gamephase {
+
+namespace {
+
+constexpr uint8_t s_mgLimit { 24 };
+
+}
+
+constexpr std::array<uint8_t, magic_enum::enum_count<Piece>()> s_materialPhaseScore = {
+    0, 1, 1, 2, 4, 0, /* white pieces */
+    0, 1, 1, 2, 4, 0 /* black pieces */
+};
+
+enum Phases : uint8_t {
+    GamePhaseMg = 0,
+    GamePhaseEg,
+};
+
+struct Score {
+    int32_t mg {};
+    int32_t eg {};
+    uint8_t materialScore {};
+
+    constexpr Score operator+(const Score& other) const noexcept
+    {
+        return { static_cast<int32_t>(mg + other.mg), static_cast<int32_t>(eg + other.eg), static_cast<uint8_t>(materialScore + other.materialScore) };
+    }
+
+    constexpr Score& operator+=(const Score& other) noexcept
+    {
+        mg += other.mg;
+        eg += other.eg;
+        materialScore += other.materialScore;
+        return *this;
+    }
+
+    /* NOTE: material score should still be incremented here! */
+    constexpr Score operator-(const Score& other) const noexcept
+    {
+        return { static_cast<int32_t>(mg - other.mg), static_cast<int32_t>(eg - other.eg), static_cast<uint8_t>(materialScore + other.materialScore) };
+    }
+
+    /* NOTE: material score should still be incremented here! */
+    constexpr Score& operator-=(const Score& other) noexcept
+    {
+        mg -= other.mg;
+        eg -= other.eg;
+        materialScore += other.materialScore;
+        return *this;
+    }
+};
+
+[[nodiscard]] constexpr int32_t taperedScore(const Score& score)
+{
+    /* we have to limit the score in case of early promotions */
+    const uint8_t mgWeight = std::min(score.materialScore, s_mgLimit);
+    const uint8_t egWeight = s_mgLimit - mgWeight;
+
+    return (score.mg * mgWeight + score.eg * egWeight) / s_mgLimit;
+}
+
+}
+

--- a/src/evaluation/pesto_tables.h
+++ b/src/evaluation/pesto_tables.h
@@ -2,6 +2,7 @@
 
 #include "bit_board.h"
 #include "board_defs.h"
+#include "evaluation/game_phase.h"
 #include "helpers/bit_operations.h"
 #include "magic_enum/magic_enum.hpp"
 #include <array>
@@ -345,41 +346,7 @@ constexpr auto generatePestoTable()
 }
 }
 
-constexpr std::array<uint8_t, magic_enum::enum_count<Piece>()> s_gamePhaseScore = {
-    0, 1, 1, 2, 4, 0, /* white pieces */
-    0, 1, 1, 2, 4, 0 /* black pieces */
-};
-
 constexpr auto s_mgTables = mg::generatePestoTable();
 constexpr auto s_egTables = eg::generatePestoTable();
-
-constexpr int32_t evaluate(const BitBoard& board)
-{
-    int32_t mgScore {};
-    int32_t egScore {};
-    uint8_t gamePhase {};
-
-    for (uint8_t wp = WhitePawn; wp <= WhiteKing; wp++) {
-        helper::bitIterate(board.pieces[wp], [&mgScore, &egScore, &gamePhase, wp](BoardPosition pos) {
-            mgScore += s_mgTables[wp][pos];
-            egScore += s_egTables[wp][pos];
-            gamePhase += s_gamePhaseScore[wp];
-        });
-    }
-
-    for (uint8_t bp = BlackPawn; bp <= BlackKing; bp++) {
-        helper::bitIterate(board.pieces[bp], [&mgScore, &egScore, &gamePhase, bp](BoardPosition pos) {
-            mgScore -= s_mgTables[bp][pos];
-            egScore -= s_egTables[bp][pos];
-            gamePhase += s_gamePhaseScore[bp];
-        });
-    }
-
-    constexpr uint8_t mgLimit { 24 };
-    const uint8_t mgGamePhase = std::min(gamePhase, mgLimit); /* 'min' in case of early promotion */
-    const uint8_t egGamePhase = mgLimit - mgGamePhase;
-
-    return (mgScore * mgGamePhase + egScore * egGamePhase) / mgLimit;
-}
 
 }

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -5,136 +5,239 @@
 #include <array>
 #include <cstdint>
 
+#include "evaluation/game_phase.h"
+#include "evaluation/pesto_tables.h"
 #include "evaluation/position_tables.h"
 #include "helpers/bit_operations.h"
+#include "helpers/game_phases.h"
 #include "movegen/bishops.h"
 #include "movegen/kings.h"
+#include "movegen/knights.h"
 #include "movegen/rooks.h"
 
 namespace evaluation {
 
 namespace {
 
-constexpr int32_t s_doublePawnPenalty { -10 };
-constexpr int32_t s_isolatedPawnPenalty { -10 };
-constexpr auto s_passedPawnBonus = std::to_array<int32_t>({ 0, 10, 30, 50, 75, 100, 150, 200 });
-constexpr int32_t s_semiOpenFileScore { 10 };
-constexpr int32_t s_openFileScore { 15 };
+constexpr auto s_doublePawnPenalty = helper::createPhaseArray<int32_t>(-10, -10);
+constexpr auto s_isolatedPawnPenalty = helper::createPhaseArray<int32_t>(-10, -10);
 
-constexpr int32_t s_bishopMobilityScore { 3 };
-constexpr int32_t s_queenMobilityScore { 1 }; /* TODO: make game phase dependent */
-constexpr int32_t s_kingShieldScore { 5 };
+using PassedPawnType = std::array<int32_t, 8>;
+constexpr auto s_passedPawnBonus = helper::createPhaseArray<PassedPawnType>(
+    PassedPawnType { 0, 10, 30, 50, 75, 100, 150, 200 },
+    PassedPawnType { 0, 10, 30, 50, 75, 100, 150, 200 });
+
+constexpr auto s_openFileScore = helper::createPhaseArray<int32_t>(15, 15);
+constexpr auto s_semiOpenFileScore = helper::createPhaseArray<int32_t>(10, 10);
+
+constexpr auto s_bishopMobilityScore = helper::createPhaseArray<int32_t>(3, 3);
+constexpr auto s_queenMobilityScore = helper::createPhaseArray<int32_t>(1, 1);
+constexpr auto s_kingShieldScore = helper::createPhaseArray<int32_t>(5, 5);
 
 }
 
 namespace position {
 
 template<Player player>
-constexpr static inline int32_t getPawnScore(const BitBoard& board, const uint64_t pawns)
+constexpr static inline gamephase::Score getPawnScore(const BitBoard& board, const uint64_t pawns)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
     helper::bitIterate(pawns, [&](BoardPosition pos) {
         const auto doubledPawns = std::popcount(pawns & s_fileMaskTable[pos]);
-        if (doubledPawns > 1)
-            score += doubledPawns * s_doublePawnPenalty;
+        if (doubledPawns > 1) {
+            score.mg += s_doublePawnPenalty[gamephase::GamePhaseMg];
+            score.eg += s_doublePawnPenalty[gamephase::GamePhaseEg];
+        }
 
-        if ((pawns & s_isolationMaskTable[pos]) == 0)
-            score += s_isolatedPawnPenalty;
+        if ((pawns & s_isolationMaskTable[pos]) == 0) {
+            score.mg += s_isolatedPawnPenalty[gamephase::GamePhaseMg];
+            score.eg += s_isolatedPawnPenalty[gamephase::GamePhaseEg];
+        }
 
         if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhitePawn];
+            score.mg += pesto::s_mgTables[WhitePawn][pos];
+            score.eg += pesto::s_egTables[WhitePawn][pos];
+
             if ((board.pieces[BlackPawn] & s_whitePassedPawnMaskTable[pos]) == 0) {
                 const uint8_t row = (pos / 8);
-                score += s_passedPawnBonus[row];
+                score.mg += s_passedPawnBonus[gamephase::GamePhaseMg][row];
+                score.eg += s_passedPawnBonus[gamephase::GamePhaseEg][row];
             }
         } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackPawn];
+            score.mg += pesto::s_mgTables[BlackPawn][pos];
+            score.eg += pesto::s_egTables[BlackPawn][pos];
+
             if ((board.pieces[WhitePawn] & s_blackPassedPawnMaskTable[pos]) == 0) {
                 const uint8_t row = (pos / 8);
-                score += s_passedPawnBonus[7 - row]; /* invert table for black */
+                score.mg += s_passedPawnBonus[gamephase::GamePhaseMg][7 - row];
+                score.eg += s_passedPawnBonus[gamephase::GamePhaseEg][7 - row];
             }
         }
-    });
-
-    return score;
-}
-
-constexpr static inline int32_t getBishopScore(const BitBoard& board, const uint64_t bishops)
-{
-    int32_t score = 0;
-
-    helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
-        const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);
-        score += std::popcount(moves) * s_bishopMobilityScore;
     });
 
     return score;
 }
 
 template<Player player>
-constexpr static inline int32_t getRookScore(const BitBoard& board, const uint64_t rooks)
+constexpr static inline gamephase::Score getKnightScore(const uint64_t knights)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
-    const uint64_t whitePawns = board.pieces[WhitePawn];
-    const uint64_t blackPawns = board.pieces[BlackPawn];
-
-    helper::bitIterate(rooks, [&](BoardPosition pos) {
-        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0)
-            score += s_openFileScore;
+    helper::bitIterate(knights, [&score](BoardPosition pos) {
 
         if constexpr (player == PlayerWhite) {
-            if ((whitePawns & s_fileMaskTable[pos]) == 0)
-                score += s_semiOpenFileScore;
-
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteKnight];
+            score.mg += pesto::s_mgTables[WhiteKnight][pos];
+            score.eg += pesto::s_egTables[WhiteKnight][pos];
         } else {
-            if ((blackPawns & s_fileMaskTable[pos]) == 0)
-                score += s_semiOpenFileScore;
+            score.materialScore += gamephase::s_materialPhaseScore[BlackKnight];
+            score.mg += pesto::s_mgTables[BlackKnight][pos];
+            score.eg += pesto::s_egTables[BlackKnight][pos];
         }
     });
 
     return score;
 }
 
-constexpr static inline int32_t getQueenScore(const BitBoard& board, const uint64_t queens)
+template<Player player>
+constexpr static inline gamephase::Score getBishopScore(const BitBoard& board, const uint64_t bishops)
 {
-    int32_t score = 0;
+    gamephase::Score score;
+
+
+    helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
+        const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);
+        const int movesCount = std::popcount(moves);
+
+        score.mg += movesCount * s_bishopMobilityScore[gamephase::GamePhaseMg];
+        score.eg += movesCount * s_bishopMobilityScore[gamephase::GamePhaseEg];
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteBishop];
+            score.mg += pesto::s_mgTables[WhiteBishop][pos];
+            score.eg += pesto::s_egTables[WhiteBishop][pos];
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackBishop];
+            score.mg += pesto::s_mgTables[BlackBishop][pos];
+            score.eg += pesto::s_egTables[BlackBishop][pos];
+        }
+    });
+
+    return score;
+}
+
+template<Player player>
+constexpr gamephase::Score getRookScore(const BitBoard& board, const uint64_t rooks)
+{
+    gamephase::Score score;
+
+    const uint64_t whitePawns = board.pieces[WhitePawn];
+    const uint64_t blackPawns = board.pieces[BlackPawn];
+
+    helper::bitIterate(rooks, [&](BoardPosition pos) {
+
+        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0) {
+            score.mg += s_openFileScore[gamephase::GamePhaseMg];
+            score.eg += s_openFileScore[gamephase::GamePhaseEg];
+        }
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteRook];
+            score.mg += pesto::s_mgTables[WhiteRook][pos];
+            score.eg += pesto::s_egTables[WhiteRook][pos];
+
+            if ((whitePawns & s_fileMaskTable[pos]) == 0) {
+                score.mg += s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg += s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackRook];
+            score.mg += pesto::s_mgTables[BlackRook][pos];
+            score.eg += pesto::s_egTables[BlackRook][pos];
+
+            if ((blackPawns & s_fileMaskTable[pos]) == 0) {
+                score.mg += s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg += s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
+        }
+    });
+
+    return score;
+}
+
+template<Player player>
+constexpr static inline gamephase::Score getQueenScore(const BitBoard& board, const uint64_t queens)
+{
+    gamephase::Score score;
 
     helper::bitIterate(queens, [&board, &score](BoardPosition pos) {
         const uint64_t moves
             = movegen::getBishopMoves(pos, board.occupation[Both])
             | movegen::getRookMoves(pos, board.occupation[Both]);
 
-        score += std::popcount(moves) * s_queenMobilityScore;
+        const int movesCount = std::popcount(moves);
+
+        score.mg += movesCount * s_queenMobilityScore[gamephase::GamePhaseMg];
+        score.eg += movesCount * s_queenMobilityScore[gamephase::GamePhaseEg];
+
+        if constexpr (player == PlayerWhite) {
+            score.materialScore += gamephase::s_materialPhaseScore[WhiteQueen];
+            score.mg += pesto::s_mgTables[WhiteQueen][pos];
+            score.eg += pesto::s_egTables[WhiteQueen][pos];
+        } else {
+            score.materialScore += gamephase::s_materialPhaseScore[BlackQueen];
+            score.mg += pesto::s_mgTables[BlackQueen][pos];
+            score.eg += pesto::s_egTables[BlackQueen][pos];
+        }
     });
 
     return score;
 }
 
 template<Player player>
-constexpr static inline int32_t getKingScore(const BitBoard& board, const uint64_t king)
+constexpr static inline gamephase::Score getKingScore(const BitBoard& board, const uint64_t king)
 {
-    int32_t score = 0;
+    gamephase::Score score;
 
     const uint64_t whitePawns = board.pieces[WhitePawn];
     const uint64_t blackPawns = board.pieces[BlackPawn];
 
     helper::bitIterate(king, [&](BoardPosition pos) {
         /* king will get a penalty for semi/open files */
-        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0)
-            score -= s_openFileScore;
+        if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0) {
+            score.mg -= s_openFileScore[gamephase::GamePhaseMg];
+            score.eg -= s_openFileScore[gamephase::GamePhaseEg];
+        }
 
         if constexpr (player == PlayerWhite) {
-            if ((whitePawns & s_fileMaskTable[pos]) == 0)
-                score -= s_semiOpenFileScore;
+            score.mg += pesto::s_mgTables[WhiteKing][pos];
+            score.eg += pesto::s_egTables[WhiteKing][pos];
+
+            if ((whitePawns & s_fileMaskTable[pos]) == 0) {
+                score.mg -= s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg -= s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
 
             const uint64_t kingShields = movegen::getKingMoves(pos) & board.occupation[PlayerWhite];
-            score += std::popcount(kingShields) * s_kingShieldScore;
+            const int shieldCount = std::popcount(kingShields);
+            score.mg += shieldCount * s_kingShieldScore[gamephase::GamePhaseMg];
+            score.eg += shieldCount * s_kingShieldScore[gamephase::GamePhaseEg];
         } else {
-            if ((blackPawns & s_fileMaskTable[pos]) == 0)
-                score -= s_semiOpenFileScore;
+            score.mg += pesto::s_mgTables[BlackKing][pos];
+            score.eg += pesto::s_egTables[BlackKing][pos];
+
+            if ((blackPawns & s_fileMaskTable[pos]) == 0) {
+                score.mg -= s_semiOpenFileScore[gamephase::GamePhaseMg];
+                score.eg -= s_semiOpenFileScore[gamephase::GamePhaseEg];
+            }
 
             const uint64_t kingShields = movegen::getKingMoves(pos) & board.occupation[PlayerBlack];
-            score += std::popcount(kingShields) * s_kingShieldScore;
+            const int shieldCount = std::popcount(kingShields);
+            score.mg += shieldCount * s_kingShieldScore[gamephase::GamePhaseMg];
+            score.eg += shieldCount * s_kingShieldScore[gamephase::GamePhaseEg];
         }
     });
 

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -34,6 +34,7 @@ constexpr auto s_bishopMobilityScore = helper::createPhaseArray<int32_t>(3, 3);
 constexpr auto s_bishopPairScore = helper::createPhaseArray<int32_t>(0, 0);
 
 constexpr auto s_knightMobilityScore = helper::createPhaseArray<int32_t>(0, 0);
+constexpr auto s_rookMobilityScore = helper::createPhaseArray<int32_t>(0, 0);
 constexpr auto s_queenMobilityScore = helper::createPhaseArray<int32_t>(1, 1);
 constexpr auto s_kingShieldScore = helper::createPhaseArray<int32_t>(5, 5);
 
@@ -151,6 +152,11 @@ constexpr gamephase::Score getRookScore(const BitBoard& board, const uint64_t ro
     const uint64_t blackPawns = board.pieces[BlackPawn];
 
     helper::bitIterate(rooks, [&](BoardPosition pos) {
+        const uint64_t moves = movegen::getRookMoves(pos, board.occupation[Both]);
+        const int movesCount = std::popcount(moves);
+
+        score.mg += movesCount * s_rookMobilityScore[gamephase::GamePhaseMg];
+        score.eg += movesCount * s_rookMobilityScore[gamephase::GamePhaseEg];
 
         if (((whitePawns | blackPawns) & s_fileMaskTable[pos]) == 0) {
             score.mg += s_openFileScore[gamephase::GamePhaseMg];

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -31,6 +31,8 @@ constexpr auto s_openFileScore = helper::createPhaseArray<int32_t>(15, 15);
 constexpr auto s_semiOpenFileScore = helper::createPhaseArray<int32_t>(10, 10);
 
 constexpr auto s_bishopMobilityScore = helper::createPhaseArray<int32_t>(3, 3);
+constexpr auto s_bishopPairScore = helper::createPhaseArray<int32_t>(0, 0);
+
 constexpr auto s_queenMobilityScore = helper::createPhaseArray<int32_t>(1, 1);
 constexpr auto s_kingShieldScore = helper::createPhaseArray<int32_t>(5, 5);
 
@@ -107,6 +109,11 @@ constexpr static inline gamephase::Score getBishopScore(const BitBoard& board, c
 {
     gamephase::Score score;
 
+    const int amntBishops = std::popcount(bishops);
+    if (amntBishops >= 2) {
+        score.mg += s_bishopPairScore[gamephase::GamePhaseMg];
+        score.eg += s_bishopPairScore[gamephase::GamePhaseEg];
+    }
 
     helper::bitIterate(bishops, [&score, &board](BoardPosition pos) {
         const uint64_t moves = movegen::getBishopMoves(pos, board.occupation[Both]);

--- a/src/evaluation/positioning.h
+++ b/src/evaluation/positioning.h
@@ -33,6 +33,7 @@ constexpr auto s_semiOpenFileScore = helper::createPhaseArray<int32_t>(10, 10);
 constexpr auto s_bishopMobilityScore = helper::createPhaseArray<int32_t>(3, 3);
 constexpr auto s_bishopPairScore = helper::createPhaseArray<int32_t>(0, 0);
 
+constexpr auto s_knightMobilityScore = helper::createPhaseArray<int32_t>(0, 0);
 constexpr auto s_queenMobilityScore = helper::createPhaseArray<int32_t>(1, 1);
 constexpr auto s_kingShieldScore = helper::createPhaseArray<int32_t>(5, 5);
 
@@ -89,6 +90,11 @@ constexpr static inline gamephase::Score getKnightScore(const uint64_t knights)
     gamephase::Score score;
 
     helper::bitIterate(knights, [&score](BoardPosition pos) {
+        const uint64_t moves = movegen::getKnightMoves(pos);
+        const int movesCount = std::popcount(moves);
+
+        score.mg += movesCount * s_knightMobilityScore[gamephase::GamePhaseMg];
+        score.eg += movesCount * s_knightMobilityScore[gamephase::GamePhaseEg];
 
         if constexpr (player == PlayerWhite) {
             score.materialScore += gamephase::s_materialPhaseScore[WhiteKnight];

--- a/src/evaluation/static_evaluation.h
+++ b/src/evaluation/static_evaluation.h
@@ -14,7 +14,7 @@
 
 namespace evaluation {
 
-constexpr int32_t materialScore(const BitBoard& board)
+constexpr int32_t staticEvaluation(const BitBoard& board)
 {
     /* we first evaluate based on "pesto score"
      * then we add mobility, double pawn etc. */

--- a/src/evaluation/static_evaluation.h
+++ b/src/evaluation/static_evaluation.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "bit_board.h"
-#include "evaluation/pesto_tables.h"
 #include "evaluation/positioning.h"
 
 #include <cstdint>
@@ -16,9 +15,7 @@ namespace evaluation {
 
 constexpr int32_t staticEvaluation(const BitBoard& board)
 {
-    /* we first evaluate based on "pesto score"
-     * then we add mobility, double pawn etc. */
-    int32_t score = pesto::evaluate(board);
+    gamephase::Score score;
 
     // Material scoring
     for (const auto piece : magic_enum::enum_values<Piece>()) {
@@ -27,15 +24,16 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
             score += position::getPawnScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteKnight:
+            score += position::getKnightScore<PlayerWhite>(board.pieces[piece]);
             break;
         case WhiteBishop:
-            score += position::getBishopScore(board, board.pieces[piece]);
+            score += position::getBishopScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteRook:
             score += position::getRookScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteQueen:
-            score += position::getQueenScore(board, board.pieces[piece]);
+            score += position::getQueenScore<PlayerWhite>(board, board.pieces[piece]);
             break;
         case WhiteKing:
             score += position::getKingScore<PlayerWhite>(board, board.pieces[piece]);
@@ -47,15 +45,16 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
             score -= position::getPawnScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackKnight:
+            score -= position::getKnightScore<PlayerBlack>(board.pieces[piece]);
             break;
         case BlackBishop:
-            score -= position::getBishopScore(board, board.pieces[piece]);
+            score -= position::getBishopScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackRook:
             score -= position::getRookScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackQueen:
-            score -= position::getQueenScore(board, board.pieces[piece]);
+            score -= position::getQueenScore<PlayerBlack>(board, board.pieces[piece]);
             break;
         case BlackKing:
             score -= position::getKingScore<PlayerBlack>(board, board.pieces[piece]);
@@ -63,7 +62,8 @@ constexpr int32_t staticEvaluation(const BitBoard& board)
         }
     }
 
-    return board.player == PlayerWhite ? score : -score;
+    const int32_t evaluation = gamephase::taperedScore(score);
+    return board.player == PlayerWhite ? evaluation : -evaluation;
 }
 
 }

--- a/src/helpers/game_phases.h
+++ b/src/helpers/game_phases.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "evaluation/game_phase.h"
+#include "magic_enum/magic_enum.hpp"
+
+namespace helper {
+
+/* Utility to create a std::array<T, N> for phase-based evaluation constants.
+ * Ensures the number of provided values matches the number of game phases.
+ * T must be explicitly specified when using complex types like nested arrays.
+ * Example: createPhaseArray<int32_t>(10, 10)
+ *         createPhaseArray<std::array<int32_t, 8>>(row1, row2)
+ * NOTE: We require T to be explicit to avoid deduction issues with brace-initialized types. */
+template<typename T, typename... Args>
+constexpr auto createPhaseArray(Args&&... values)
+    -> std::array<T, sizeof...(Args)>
+{
+    static_assert(sizeof...(Args) == magic_enum::enum_count<evaluation::gamephase::Phases>(),
+        "Wrong number of phase values");
+    return std::array<T, sizeof...(Args)> { std::forward<Args>(values)... };
+}
+
+}
+

--- a/src/helpers/game_phases.h
+++ b/src/helpers/game_phases.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "evaluation/game_phase.h"
+#include "evaluation/pesto_tables.h"
 #include "magic_enum/magic_enum.hpp"
 
 namespace helper {
@@ -18,6 +19,57 @@ constexpr auto createPhaseArray(Args&&... values)
     static_assert(sizeof...(Args) == magic_enum::enum_count<evaluation::gamephase::Phases>(),
         "Wrong number of phase values");
     return std::array<T, sizeof...(Args)> { std::forward<Args>(values)... };
+}
+
+/* Adds a phase-specific score (midgame and endgame) to the given score object.
+ * `values` must be an array of size 2, where index 0 = midgame, index 1 = endgame.
+ */
+template<typename T>
+constexpr void addPhaseScore(evaluation::gamephase::Score& score, const std::array<T, 2>& values)
+{
+    score.mg += values[evaluation::gamephase::GamePhaseMg];
+    score.eg += values[evaluation::gamephase::GamePhaseEg];
+}
+
+/* Adds a phase-specific score to the given score object, scaled by a float multiplier.
+ * Useful when applying scores based on piece counts, shield counts, mobility, etc.
+ */
+template<typename T>
+constexpr void addPhaseScore(evaluation::gamephase::Score& score, const std::array<T, 2>& values, float multiplier)
+{
+    score.mg += values[evaluation::gamephase::GamePhaseMg] * multiplier;
+    score.eg += values[evaluation::gamephase::GamePhaseEg] * multiplier;
+}
+
+/* Subtracts a phase-specific score from the given score object.
+ * Mirrors addPhaseScore(), but for penalties or score reductions.
+ */
+template<typename T>
+constexpr void subPhaseScore(evaluation::gamephase::Score& score, const std::array<T, 2>& values)
+{
+    score.mg -= values[evaluation::gamephase::GamePhaseMg];
+    score.eg -= values[evaluation::gamephase::GamePhaseEg];
+}
+
+/* Subtracts a phase-specific score from the score object, scaled by a float multiplier.
+ * Useful when reducing score based on factors like lack of development, pawn weaknesses, etc.
+ */
+template<typename T>
+constexpr void subPhaseScore(evaluation::gamephase::Score& score, const std::array<T, 2>& values, float multiplier)
+{
+    score.mg -= values[evaluation::gamephase::GamePhaseMg] * multiplier;
+    score.eg -= values[evaluation::gamephase::GamePhaseEg] * multiplier;
+}
+
+/* Adds midgame and endgame scores for a specific piece at a given board position,
+ * using precomputed PESTO piece-square tables.
+ * Also the material score (game phase dependent) is increased whenever probed
+ */
+constexpr void addPestoPhaseScore(evaluation::gamephase::Score& score, Piece piece, BoardPosition pos)
+{
+    score.mg += evaluation::pesto::s_mgTables[piece][pos];
+    score.eg += evaluation::pesto::s_egTables[piece][pos];
+    score.materialScore += evaluation::gamephase::s_materialPhaseScore[piece];
 }
 
 }

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -1,4 +1,4 @@
-#include "evaluation/material_scoring.h"
+#include "evaluation/static_evaluation.h"
 #include "parsing/fen_parser.h"
 
 #include <catch2/catch_test_macros.hpp>
@@ -20,7 +20,7 @@ TEST_CASE("Scoring", "[scoring]")
             boardB.reset();
             boardB.player = PlayerBlack; /* flip side */
 
-            REQUIRE(evaluation::materialScore(boardW) == evaluation::materialScore(boardB));
+            REQUIRE(evaluation::staticEvaluation(boardW) == evaluation::staticEvaluation(boardB));
         }
 
         SECTION("Position 1")
@@ -31,7 +31,7 @@ TEST_CASE("Scoring", "[scoring]")
             REQUIRE(boardW.has_value());
             REQUIRE(boardB.has_value());
 
-            REQUIRE(evaluation::materialScore(*boardW) == evaluation::materialScore(*boardB));
+            REQUIRE(evaluation::staticEvaluation(*boardW) == evaluation::staticEvaluation(*boardB));
         }
     }
 


### PR DESCRIPTION
Our current static evaluation (renamed now) does not handle game phases very well. 
We should now be able to control game phase scores in a more dynamic way.
Also the performance from only looping each piece once is quite massive:

```
Score of Meltdown Build vs Meltdown Baseline: 275 - 200 - 281  [0.550] 756
...      Meltdown Build playing White: 156 - 92 - 131  [0.584] 379
...      Meltdown Build playing Black: 119 - 108 - 150  [0.515] 377
...      White vs Black: 264 - 211 - 281  [0.535] 756
Elo difference: 34.6 +/- 19.7, LOS: 100.0 %, DrawRatio: 37.2 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```