### PR TITLE
Revert "move_gen: Implement half-search for `getPieceAtSquare`"

### DIFF
--- a/src/bit_board.h
+++ b/src/bit_board.h
@@ -47,33 +47,15 @@ struct BitBoard {
         occupation[Both] = occupation[White] | occupation[Black];
     }
 
-    template<Player player>
-    constexpr std::optional<Piece> getTargetAtSquare(uint64_t square) const
+    constexpr std::optional<Piece> getPieceAtSquare(uint64_t square) const
     {
-        if constexpr (player == PlayerWhite) {
-            for (const auto piece : s_blackPieces) {
-                if (square & pieces[piece]) {
-                    return piece;
-                }
-            }
-        } else {
-            for (const auto piece : s_whitePieces) {
-                if (square & pieces[piece]) {
-                    return piece;
-                }
+        for (const auto piece : magic_enum::enum_values<Piece>()) {
+            if (square & pieces[piece]) {
+                return piece;
             }
         }
 
         return std::nullopt;
-    }
-
-    // Helper: calling within loops will mean redundant colour checks
-    constexpr std::optional<Piece> getTargetAtSquare(uint64_t square, Player player) const
-    {
-        if (player == PlayerWhite)
-            return getTargetAtSquare<PlayerWhite>(square);
-        else
-            return getTargetAtSquare<PlayerBlack>(square);
     }
 
     constexpr bool isQuietPosition() const
@@ -97,3 +79,4 @@ struct BitBoard {
     uint32_t fullMoves {};
     uint32_t halfMoves {};
 };
+

--- a/src/evaluation/history_moves.h
+++ b/src/evaluation/history_moves.h
@@ -21,7 +21,7 @@ public:
             return; // nothing to do
         }
 
-        const auto movePiece = board.getTargetAtSquare(move.fromSquare(), board.player);
+        const auto movePiece = board.getPieceAtSquare(move.fromSquare());
 
         if (!movePiece.has_value())
             return; // nothing to do
@@ -40,3 +40,4 @@ private:
 };
 
 }
+

--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -81,12 +81,11 @@ public:
         /* piece that will track the scoring of next piece */
         Piece nextPiece = move.piece();
 
-        Player player = board.player;
-
-        if (const auto initialPiece = board.getTargetAtSquare(move.toSquare(), board.player)) {
+        if (const auto initialPiece = board.getPieceAtSquare(move.toSquare())) {
             gain[depth] = s_pieceValues[*initialPiece];
         }
 
+        Player player = board.player;
         while (attackers) {
             depth++;
 

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -212,8 +212,8 @@ inline bool generateSyzygyMoves(const BitBoard& board, movegen::ValidMoves& move
         if (!from.has_value() || !to.has_value())
             continue;
 
-        const auto piece = board.getTargetAtSquare(helper::positionToSquare(*from), board.player);
-        const auto target = board.getTargetAtSquare(helper::positionToSquare(*to), board.player);
+        const auto piece = board.getPieceAtSquare(helper::positionToSquare(*from));
+        const auto target = board.getPieceAtSquare(helper::positionToSquare(*to));
         if (!piece.has_value())
             continue;
 


### PR DESCRIPTION
This reverts commit 4448678b1cbd2e3c90ca19eee0be64eeac461f33.

Ran some tests and it seems that this commit causes a severe elo drop.
I did some initial investigations and we try to extract the target from the "from position". This is not the target hence it will not find a piece. Tried to make a hot fix, but I think it's better to revert this for now and fix the issue :)