### PR TITLE
tests: improve tournament test setup

### DIFF
--- a/tests/cute-chess/config.json.example
+++ b/tests/cute-chess/config.json.example
@@ -12,7 +12,7 @@
     "tournament": {
         "rounds": 100,
         "concurrency": 8,
-        "time_control": "0/8+0.08",
+        "time_control": "tc=0/8+0.08 (NOTE: can also be st=0.3 for eg. 300ms / move)",
         "opening_book": "tests/books/8moves_v3.pgn",
         "opening_book_moves": 8,
         "resign_move_count": 5,

--- a/tests/cute-chess/run-tournament.sh
+++ b/tests/cute-chess/run-tournament.sh
@@ -55,11 +55,11 @@ echo "<ctrl-c> will stop tests early"
 cutechess-cli \
   -engine cmd="$ENGINE1_PATH" name="$ENGINE1_NAME" $ENGINE1_OPTIONS \
   -engine cmd="$ENGINE2_PATH" name="$ENGINE2_NAME" $ENGINE2_OPTIONS \
-  -each tc=$TIME_CONTROL proto=uci \
-  -concurrency $CONCURRENCY -rounds $ROUNDS -repeat -games 2 \
+  -each proto=uci $TIME_CONTROL \
+  -concurrency $CONCURRENCY -rounds $ROUNDS -repeat 2 -games 2 \
   $SPRT_STRING \
   -openings file=$OPENING_BOOK plies=$OPENING_BOOK_MOVES order=random policy=round \
-  -ratinginterval $CONCURRENCY -pgnout "$PGN_OUTPUT" -resign movecount=$RESIGN_MOVES score=$RESIGN_SCORE -maxmoves 200 \
+  -ratinginterval $CONCURRENCY -outcomeinterval $CONCURRENCY -pgnout "$PGN_OUTPUT" -resign movecount=$RESIGN_MOVES score=$RESIGN_SCORE -maxmoves 200 \
   -resultformat default > $RESULT_OUTPUT
 
 echo "Tournament finished!"


### PR DESCRIPTION
This commit adds support for adjusting time control. Before only "tc" option was supported.
Now it's possible to use "st" as well.

Using st will be a more deterministic test but it will not test our eg. time management. For most of our tests st should probably be used instead.

Also added some more parameters to the cutechess caller; make it more consistent and only print out results when we've actually played an equal / concurrent amount of games.