### PR TITLE
Add futility and razoring pruning

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -362,6 +362,24 @@ private:
             }
         }
 
+        /* https://www.chessprogramming.org/Razoring (Strelka) */
+        if (!isPv && !isChecked && depth <= s_reductionLimit) {
+            int32_t score = staticEval + s_razorMarginShallow;
+            if (score < beta) {
+                if (depth == 1) {
+                    int32_t newScore = quiesence(board, alpha, beta);
+                    return (newScore > score) ? newScore : score;
+                }
+
+                score += s_razorMarginDeep;
+                if (score < beta && depth <= s_razorDeepReductionLimit) {
+                    const int32_t newScore = quiesence(board, alpha, beta);
+                    if (newScore < beta)
+                        return (newScore > score) ? newScore : score;
+                }
+            }
+        }
+
         bool tbMoves = false;
         movegen::ValidMoves moves {};
         if (syzygy::isTableActive(board)) {
@@ -634,6 +652,11 @@ private:
     /* search configs */
     constexpr static inline uint32_t s_fullDepthMove { 4 };
     constexpr static inline uint32_t s_reductionLimit { 3 };
+    constexpr static inline int32_t s_futilityMargin { 100 };
+    constexpr static inline int32_t s_futilityEvaluationMargin { 120 };
+    constexpr static inline int32_t s_razorMarginShallow { 125 };
+    constexpr static inline int32_t s_razorMarginDeep { 175 };
+    constexpr static inline uint8_t s_razorDeepReductionLimit { 2 };
     constexpr static inline uint32_t s_defaultAmountMoves { 75 };
 
     constexpr static inline uint8_t s_aspirationWindow { 50 };

--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -342,6 +342,17 @@ private:
             depth++;
         }
 
+        const int32_t staticEval = staticEvaluation(board);
+
+        /* https://www.chessprogramming.org/Reverse_Futility_Pruning */
+        if (depth < s_reductionLimit && !isPv && !isChecked) {
+            const bool withinFutilityMargin = abs(beta - 1) > (s_minScore + s_futilityMargin);
+            const int32_t evalMargin = s_futilityEvaluationMargin * depth;
+
+            if (withinFutilityMargin && (staticEval - evalMargin) >= beta)
+                return staticEval - evalMargin;
+        }
+
         /* dangerous to repeat null search on a null search - skip it here */
         if constexpr (searchType != SearchType::NullSearch) {
             if (depth > s_nullMoveReduction && !isChecked && m_ply) {


### PR DESCRIPTION
See each commit for details.

A while ago since we added pruning. About time to collect some easy elo :))

Results speak for themselves:
```
Score of Meltdown Build vs Meltdown Baseline: 130 - 63 - 115  [0.609] 308
Finished game 306 (Meltdown Baseline vs Meltdown Build): * {No result}
Score of Meltdown Build vs Meltdown Baseline: 130 - 63 - 115  [0.609] 308
...      Meltdown Build playing White: 73 - 30 - 52  [0.639] 155
...      Meltdown Build playing Black: 57 - 33 - 63  [0.578] 153
...      White vs Black: 106 - 87 - 115  [0.531] 308
Elo difference: 76.8 +/- 31.0, LOS: 100.0 %, DrawRatio: 37.3 %
SPRT: llr 2.98 (101.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```
