### PR TITLE
targets: add windows cross compilation targets

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     container:
-      image: hansbinderup/meson-gcc:1.0
+      image: hansbinderup/meson-gcc:1.1
       options: --user root
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
     name: Nightly
     runs-on: ubuntu-latest
     container:
-      image: hansbinderup/meson-gcc:1.0
+      image: hansbinderup/meson-gcc:1.1
       options: --user root
     steps:
       - name: Checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: hansbinderup/meson-gcc:1.0
+      image: hansbinderup/meson-gcc:1.1
       options: --user root
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: hansbinderup/meson-gcc:1.0
+      image: hansbinderup/meson-gcc:1.1
       options: --user root
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ NOTE: this is a hobby project that is work in progress.
 
 C++26 chess engine.
 
-Design goals:
+<details>
+<summary>Design goals</summary>
 
 ```
 #1 Fully stack allocated - engine should at no point allocate heap memory
@@ -21,8 +22,18 @@ Comments:
 #3 Starting this project I spend a fair amount of time getting some inspiration. Mostly for algorithms. And I often observed that the implementation of the algorithms were pretty hard to read. I believe that it's possible to implement these fancy and "magic" algorithms in a way that is readable but also don't compromise #2. When it comes to the "magic" algorithms etc. my goal is to separate the logic into method where it's easy(er) to follow what's going on based on the documentation that is currently available.
 
 #4 Each component should, if possible, be decoupled so that it is easy to implement newer and potentially better algorithms if such were to be found.
+</details>
 
 ## Getting started
+
+The build scripts currently support Linux and Windows. The OS is automatically detected on build.
+
+### Download Meltdown release
+
+The easiest way to install Meltdown is by downloading one of the releases from the [release page](https://github.com/hansbinderup/meltdown-chess-engine/tags).
+All binaries are statically compiled so it should be easy to run.
+
+### Compiling through Docker
 
 1. Setup [docker](https://docs.docker.com/get-started/get-docker/)
 2. Run docker iteractively: `./docker/run.sh`
@@ -30,6 +41,11 @@ Comments:
     * For release/optimized build: `./scripts/build.sh -r` (-r is optional and will run the compiled executable)
     * For debugging in gdb: `./scripts/debug.sh`
     * Compile and run unit-tests: `./scripts/unit_test.sh`
+
+### Compiling without Docker
+
+If you prefer to compile without Docker you must ensure that `meson` (min. v1.1) is installed and your compiler supports cpp26.
+You can then run step #3 from above.
 
 ## Nightly builds
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM archlinux:latest
 RUN pacman -Sy --noconfirm \
     base-devel \
     gcc \
+    mingw-w64-gcc \
     meson \
     ninja \
     gdb \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # NOTE: should be run from directory of Dockerfile
-docker build -t hansbinderup/meson-gcc:1.0 .
+docker build -t hansbinderup/meson-gcc:1.1 .

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,4 +6,4 @@ args="--privileged \
     -w /workspaces/$(basename "$(pwd)")"
 
 
-docker run -it $args hansbinderup/meson-gcc:1.0
+docker run -it $args hansbinderup/meson-gcc:1.1

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,11 @@ fmt_dep = fmt.get_variable('fmt_dep')
 fathom = subproject('fathom')
 fathom_dep = fathom.get_variable('fathom_dep')
 
+# extra steps are required for windows static binaries
+if host_machine.system() == 'windows'
+   add_project_link_arguments('-static', '-static-libgcc', '-static-libstdc++',  language: 'cpp')
+endif
+
 meltdown_dep = declare_dependency(
   include_directories: 'src',
   dependencies: [magic_enum_dep, fmt_dep, fathom_dep]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,8 +15,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ ! -d "$BUILD_DIR" ]; then
-    echo "Setting up Meson..."
-    meson setup "$BUILD_DIR" --cross-file targets/linux-native.txt --buildtype=release
+    NATIVE_TARGET=$(scripts/get-native-target.sh)
+    echo "Setting up Meson for $NATIVE_TARGET"
+    meson setup "$BUILD_DIR" --cross-file "targets/$NATIVE_TARGET" --buildtype=release
 fi
 
 ln -sf "$BUILD_DIR"/compile_commands.json .

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -8,9 +8,11 @@ BUILD_DIR=".build-ci"
 # List of elements that we cross compile.
 # They refer to the .txt files in our 'targets' folder
 ARCHS=(
+    "linux-native"
     "linux-gcc-x86-64-v2"
     "linux-gcc-x86-64-v3"
-    "linux-native"
+    "windows-gcc-x86-64-v2"
+    "windows-gcc-x86-64-v3"
 )
 
 for ARCH in "${ARCHS[@]}"; do

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -13,6 +13,8 @@ RELEASE_DIR=".release"
 ARCHS=(
     "linux-gcc-x86-64-v2" 
     "linux-gcc-x86-64-v3"
+    "windows-gcc-x86-64-v2"
+    "windows-gcc-x86-64-v3"
 )
 
 # Ensure that we always have an empty release folder
@@ -29,7 +31,11 @@ for ARCH in "${ARCHS[@]}"; do
     meson compile -C "$BUILD_DIR"
 
     # Rename the binary with architecture and version info 
-    cp "$BUILD_DIR/meltdown-chess-engine" "$RELEASE_DIR/meltdown-$VERSION-$ARCH"
+    if [[ -f "$BUILD_DIR/meltdown-chess-engine" ]]; then
+        cp "$BUILD_DIR/meltdown-chess-engine" "$RELEASE_DIR/meltdown-$VERSION-$ARCH"
+    elif [[ -f "$BUILD_DIR/meltdown-chess-engine.exe" ]]; then
+        cp "$BUILD_DIR/meltdown-chess-engine.exe" "$RELEASE_DIR/meltdown-$VERSION-$ARCH.exe"
+    fi
 
     echo "Finished building for $ARCH."
 done

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -5,7 +5,9 @@ set -e
 BUILD_DIR=".debug"
 
 if [ ! -d "$BUILD_DIR" ]; then
-    meson setup "$BUILD_DIR" --cross-file targets/linux-native.txt
+    NATIVE_TARGET=$(scripts/get-native-target.sh)
+    echo "Setting up Meson for $NATIVE_TARGET"
+    meson setup "$BUILD_DIR" --cross-file "targets/$NATIVE_TARGET"
 fi
 
 ln -sf "$BUILD_DIR"/compile_commands.json .

--- a/scripts/get-native-target.sh
+++ b/scripts/get-native-target.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+    echo "linux-native.txt"
+elif [[ "$(uname -s)" =~ MINGW|MSYS|CYGWIN ]]; then
+    echo "windows-native.txt"
+else
+    echo "Error: native build was not detected" >&2
+    exit 1
+fi
+
+exit 0
+

--- a/src/engine/tt_hash_table.h
+++ b/src/engine/tt_hash_table.h
@@ -125,7 +125,10 @@ public:
     static uint16_t getHashFull()
     {
         /* should be returned as permill */
-        return std::min((1000 * s_hashCount.load(std::memory_order_relaxed)) / s_ttHashSize, 1000UL);
+        constexpr uint16_t maxValue { 1000 };
+        const uint16_t permill = (1000 * s_hashCount.load(std::memory_order_relaxed)) / s_ttHashSize;
+
+        return std::min(permill, maxValue);
     }
 
     using ProbeResult = std::pair<int32_t, movegen::Move>;

--- a/targets/windows-gcc-x86-64-v2.txt
+++ b/targets/windows-gcc-x86-64-v2.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-gcc-ar'
+strip = 'x86_64-w64-mingw32-strip'
+ld = 'x86_64-w64-mingw32-ld'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[built-in options]
+cpp_args = ['-march=x86-64-v2', '-static']
+c_args = ['-march=x86-64-v2', '-static']
+default_library = 'static'

--- a/targets/windows-gcc-x86-64-v3.txt
+++ b/targets/windows-gcc-x86-64-v3.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-gcc-ar'
+strip = 'x86_64-w64-mingw32-strip'
+ld = 'x86_64-w64-mingw32-ld'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[built-in options]
+cpp_args = ['-march=x86-64-v3', '-static']
+c_args = ['-march=x86-64-v3', '-static']
+default_library = 'static'

--- a/targets/windows-native.txt
+++ b/targets/windows-native.txt
@@ -1,0 +1,16 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-gcc-ar'
+strip = 'x86_64-w64-mingw32-strip'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[built-in options]
+cpp_args = ['-march=native', '-static']
+c_args = ['-march=native', '-static']
+default_library = 'static'


### PR DESCRIPTION
This commit adds support for windows cross compilation.

* mingw-w64-gcc compiler added to docker file
* windows-x86-64-v2/v3 targets added
* added automatic support for native builds using the build scripts
* updated CI to build windows releases as well

NOTE: changes to tt_hash_table was necessary as compiler complained about mismatching types. Now it should compile for both linux and windows.

DISCLAIMER: I don't have access to windows, so the whole windows shebang is untested. I'm asking some friends if they can try to run it for me before merging.

closes #39 
closes #41 