### PR TITLE
tests: add script to build baseline

### DIFF
--- a/tests/cute-chess/.gitignore
+++ b/tests/cute-chess/.gitignore
@@ -1,2 +1,3 @@
 outputs
 config.json
+meltdown-*

--- a/tests/cute-chess/build-baseline.sh
+++ b/tests/cute-chess/build-baseline.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e  # Exit on any error
+
+# Check for input
+if [ -z "$1" ]; then
+    echo "Usage: $0 <target-branch>"
+    exit 1
+fi
+
+target_branch="$1"
+
+# Save current branch name
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Stash changes if needed
+stash_applied=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Stashing local changes..."
+    git stash push -u -m "temp-stash-for-branch-switch"
+    stash_applied=true
+fi
+
+# Switch to target branch
+echo "Checking out $target_branch..."
+git checkout "$target_branch"
+
+# Run build
+echo "Running build..."
+scripts/build.sh
+cp .build/meltdown-chess-engine tests/cute-chess/meltdown-baseline
+
+# Return to original branch
+echo "Returning to $current_branch..."
+git checkout "$current_branch"
+
+# Re-apply stashed changes if any
+if $stash_applied; then
+    echo "Reapplying stashed changes..."
+    git stash pop
+fi
+
+echo "Done"
+


### PR DESCRIPTION
This commit adds a helper script to build a baseline for testing. You can simply call this script with the branch you want to build from. The script will ensure your current git state is restored etc.

Reasoning: I found myself building main as a baseline and it became annoying to handle that myself. Now we can just call this script and it's automatic.