### PR TITLE
uci_handler: add authors print out

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
         "============================\n\n");
 
     fmt::print("Engine:      Meltdown\n"
-               "Author:      Hans Binderup\n"
+               "Authors:     Run 'authors'\n"
                "Github:      hansbinderup/meltdown-chess-engine\n"
                "Version:     {}\n"
                "Build hash:  {}\n"

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -6,6 +6,7 @@
 #include "parsing/input_parsing.h"
 
 #include "syzygy/syzygy.h"
+#include "version/version.h"
 
 #include <iostream>
 #include <string_view>
@@ -70,6 +71,8 @@ private:
             return handlePerft(args);
         } else if (command == "help") {
             return handleHelp();
+        } else if (command == "authors") {
+            return handleAuthors();
         } else if (command == "quit" || command == "exit") {
             s_isRunning = false;
         } else {
@@ -298,6 +301,12 @@ private:
         return true;
     }
 
+    static bool handleAuthors()
+    {
+        fmt::println("{}", s_meltdownAuthors);
+        return true;
+    }
+
     static bool handleHelp()
     {
         fmt::print("\nMeltdown communicates over UCI protocol.\n"
@@ -309,8 +318,9 @@ private:
                    "debug clear         :  clear all scoring tables\n"
                    "debug options       :  print all options\n"
                    "debug syzygy        :  run syzygy evaluation on current position\n"
+                   "authors             :  print author information\n"
                    "version             :  print version information\n"
-                   "quit                :  stop the engine\n");
+                   "quit                :  stop the engine\n\n");
 
         return true;
     }

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -73,6 +73,8 @@ private:
             return handleHelp();
         } else if (command == "authors") {
             return handleAuthors();
+        } else if (command == "version") {
+            return handleVersion();
         } else if (command == "quit" || command == "exit") {
             s_isRunning = false;
         } else {
@@ -304,6 +306,16 @@ private:
     static bool handleAuthors()
     {
         fmt::println("{}", s_meltdownAuthors);
+        return true;
+    }
+
+    static bool handleVersion()
+    {
+        fmt::print("Version:     {}\n"
+                   "Build hash:  {}\n"
+                   "Build type:  {}\n"
+                   "Builtin:     {}\n\n",
+            s_meltdownVersion, s_meltdownBuildHash, s_meltdownBuildType, s_meltdownBuiltinFeature);
         return true;
     }
 

--- a/version/meson.build
+++ b/version/meson.build
@@ -1,11 +1,13 @@
 meltdown_version = get_option('meltdown-version')
 meltdown_hash = run_command('git', 'rev-parse',  '--short', 'HEAD').stdout().strip()
 meltdown_build_type = get_option('buildtype')
+meltdown_authors = run_command('git', 'shortlog',  '-sn', 'HEAD').stdout().replace('\n', '\\n"\n"')
 
 conf_data = configuration_data({
     'MELTDOWN_VERSION' : meltdown_version,
     'MELTDOWN_HASH' : meltdown_hash,
     'MELTDOWN_BUILD_TYPE' : meltdown_build_type,
+    'MELTDOWN_AUTHORS': meltdown_authors,
 })
 
 configure_file(

--- a/version/version.h.in
+++ b/version/version.h.in
@@ -5,6 +5,7 @@
 constexpr static inline std::string_view s_meltdownVersion { "@MELTDOWN_VERSION@" };
 constexpr static inline std::string_view s_meltdownBuildHash { "@MELTDOWN_HASH@" };
 constexpr static inline std::string_view s_meltdownBuildType { "@MELTDOWN_BUILD_TYPE@" };
+constexpr static inline std::string_view s_meltdownAuthors { "@MELTDOWN_AUTHORS@" };
 
 #ifdef __BMI2__
 constexpr static inline std::string_view s_meltdownBuiltinFeature { "BMI2" };


### PR DESCRIPTION
This commit adds auto generated author information.
I can't take credits for all the engine work, so I want to make sure
that authors that help contributing to the engine is also praised. Their
name will now be embedded in the engine as a way to show appreciation
for the support and contributions :)

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>

Example: 

```
============================
          MELTDOWN          
        Chess Engine        
============================

Engine:      Meltdown
Authors:     Run 'authors'
Github:      hansbinderup/meltdown-chess-engine
Version:     0.0.0-dev
Build hash:  f4f959b
Build type:  release
Builtin:     BMI2

authors
   186  Hans Binderup
     3  Clara Shepherd
```