### PR TITLE
helpers: add formatting helper

### DIFF
--- a/src/board_defs.h
+++ b/src/board_defs.h
@@ -3,7 +3,6 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
-#include <limits>
 
 enum Player {
     PlayerWhite,

--- a/src/engine/move_handling.h
+++ b/src/engine/move_handling.h
@@ -3,11 +3,14 @@
 #include "attack_generation.h"
 #include "bit_board.h"
 #include "engine/zobrist_hashing.h"
-#include "fmt/ranges.h"
-#include "magic_enum/magic_enum.hpp"
+#include "helpers/formatters.h"
 #include "movegen/move_generation.h"
 #include "movegen/move_types.h"
 #include "parsing/piece_parsing.h"
+
+#include "fmt/ranges.h"
+#include "magic_enum/magic_enum.hpp"
+
 #include <cstring>
 
 namespace engine {
@@ -285,7 +288,7 @@ constexpr void printPositionDebug(const BitBoard& board)
         "HalfMoves: {}\n"
         "EnPessant: {}\n"
         "Hash: {}\n",
-        magic_enum::enum_name(board.player),
+        board.player,
         board.fullMoves,
         board.halfMoves,
         board.enPessant ? magic_enum::enum_name(*board.enPessant) : "none",

--- a/src/evaluation/perft.h
+++ b/src/evaluation/perft.h
@@ -4,7 +4,7 @@
 #include "engine/move_handling.h"
 #include <chrono>
 
-#include "fmt/base.h"
+#include "helpers/formatters.h"
 
 class Perft {
 public:

--- a/src/helpers/formatters.h
+++ b/src/helpers/formatters.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "movegen/move_types.h"
+
+#include "magic_enum/magic_enum.hpp"
+#include <fmt/core.h>
+#include <string_view>
+#include <type_traits>
+
+/* generic formatter to format enum types */
+template<typename T>
+    requires std::is_enum_v<T>
+struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto format(const T& value, FormatContext& ctx) const
+    {
+        std::string_view name = magic_enum::enum_name(value);
+        if (name.empty()) {
+            /* should not happen, but have a fall back anyways */
+            return fmt::format_to(ctx.out(), "{}", magic_enum::enum_integer(value));
+        } else {
+            return fmt::format_to(ctx.out(), "{}", magic_enum::enum_name(value));
+        }
+    }
+};
+
+/* Move type formatter - allows for easy formatting of Moves */
+template<>
+struct fmt::formatter<movegen::Move> : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto format(const movegen::Move& m, FormatContext& ctx) const
+    {
+        char fromC = 'a' + (m.fromPos() % 8); // Column
+        char fromR = '1' + (m.fromPos() / 8); // Row
+        char toC = 'a' + (m.toPos() % 8); // Column
+        char toR = '1' + (m.toPos() / 8); // Row
+
+        if (m.promotionType() != PromotionNone) {
+            return fmt::format_to(ctx.out(), "{}{}{}{}{}", fromC, fromR, toC, toR, promotionToString(m.promotionType()));
+        }
+
+        return fmt::format_to(ctx.out(), "{}{}{}{}", fromC, fromR, toC, toR);
+    }
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-
 #include "uci_handler.h"
 #include "version/version.h"
 

--- a/src/movegen/move_types.h
+++ b/src/movegen/move_types.h
@@ -1,12 +1,9 @@
 #pragma once
 
 #include "board_defs.h"
+#include "helpers/bit_operations.h"
 
 #include <cstdint>
-#include <string_view>
-
-#include "fmt/format.h"
-#include "helpers/bit_operations.h"
 
 namespace movegen {
 
@@ -32,7 +29,7 @@ public:
     Move() = default;
 
     explicit Move(uint32_t ext_data)
-        : data(ext_data) {};
+        : data(ext_data) { };
 
     explicit Move(uint64_t from, uint64_t to, uint64_t piece, uint64_t promotion, uint64_t castle, uint64_t capture, uint64_t enPessant, uint64_t takeEnPessant)
         : data(
@@ -222,21 +219,3 @@ private:
 };
 
 }
-
-template<>
-struct fmt::formatter<movegen::Move> : fmt::formatter<std::string_view> {
-    template<typename FormatContext>
-    auto format(const movegen::Move& m, FormatContext& ctx) const
-    {
-        char fromC = 'a' + (m.fromPos() % 8); // Column
-        char fromR = '1' + (m.fromPos() / 8); // Row
-        char toC = 'a' + (m.toPos() % 8); // Column
-        char toR = '1' + (m.toPos() / 8); // Row
-
-        if (m.promotionType() != PromotionNone) {
-            return fmt::format_to(ctx.out(), "{}{}{}{}{}", fromC, fromR, toC, toR, promotionToString(m.promotionType()));
-        }
-
-        return fmt::format_to(ctx.out(), "{}{}{}{}", fromC, fromR, toC, toR);
-    }
-};

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -186,7 +186,7 @@ inline void printDtzDebug(const BitBoard& board)
             if (!from.has_value() || !to.has_value())
                 continue;
 
-            fmt::println("Move {}->{}, wdl: {} dtz: {}", magic_enum::enum_name(*from), magic_enum::enum_name(*to), magic_enum::enum_name(wdl), TB_GET_DTZ(res));
+            fmt::println("Move {}->{}, wdl: {} dtz: {}", *from, *to, wdl, TB_GET_DTZ(res));
         }
         fmt::print("\n");
     }

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -2,6 +2,7 @@
 
 #include "evaluation/evaluator.h"
 #include "evaluation/perft.h"
+#include "helpers/formatters.h"
 #include "parsing/fen_parser.h"
 #include "parsing/input_parsing.h"
 
@@ -283,7 +284,7 @@ private:
             fmt::println("Syzygy path: {}", s_syzygyPath);
             int32_t score = 0;
             const auto wdl = syzygy::probeWdl(s_board, score);
-            fmt::println("wdl: {}, score: {}, table size: {}", magic_enum::enum_name(wdl), score, syzygy::tableSize());
+            fmt::println("wdl: {}, score: {}, table size: {}", wdl, score, syzygy::tableSize());
             if (!(wdl == syzygy::WdlResultFailed || wdl == syzygy::WdlResultTableNotActive))
                 syzygy::printDtzDebug(s_board);
         }


### PR DESCRIPTION
This commit adds formatting helpers.
We previously had one formatting helper for "Moves". The formatting library is quite powerful so we might as well use it a little more.

An example of this is generic enum formatting. We can now simply paste an enum into the formatter and it will return the static name of the enum, pretty cool.