### PR TITLE
evaluator: add 50 moves draw rule

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -308,8 +308,11 @@ private:
         const bool isRoot = m_ply == 0;
 
         m_moveOrdering.pvTable().updateLength(m_ply);
-        if (m_ply && m_repetition.isRepetition(m_hash)) {
-            return 0; /* draw score */
+        if (m_ply) {
+            /* FIXME: make a little more sophisticated with material count etc */
+            const bool isDraw = m_repetition.isRepetition(m_hash) || board.halfMoves >= 100;
+            if (isDraw)
+                return 0; /* draw score */
         }
 
         const bool isPv = beta - alpha > 1;


### PR DESCRIPTION
This commit makes the engine aware of the 50 move draw rule. In my previous tests I've seen a lot of draws due to 50 move draw rule. I think it's about time that we teach the engine about this rule to avoid those draws if not necessary.

Initial tests:

```
Score of Meltdown Build vs Meltdown Baseline: 130 - 125 - 145  [0.506] 400
...      Meltdown Build playing White: 72 - 57 - 71  [0.537] 200
...      Meltdown Build playing Black: 58 - 68 - 74  [0.475] 200
...      White vs Black: 140 - 115 - 145  [0.531] 400
Elo difference: 4.3 +/- 27.2, LOS: 62.3 %, DrawRatio: 36.3 %
SPRT: llr -0.0351 (-1.2%), lbound -2.94, ubound 2.94

Player: Meltdown Build
   "Draw by 3-fold repetition": 104
   "Draw by fifty moves rule": 17
   "Draw by insufficient mating material": 22
   "Draw by stalemate": 2
   "Loss: Black mates": 57
   "Loss: White mates": 68
   "Win: Black mates": 58
   "Win: White mates": 72
Player: Meltdown Baseline
   "Draw by 3-fold repetition": 104
   "Draw by fifty moves rule": 17
   "Draw by insufficient mating material": 22
   "Draw by stalemate": 2
   "Loss: Black mates": 58
   "Loss: White mates": 72
   "Win: Black mates": 57
   "Win: White mates": 68
Finished match
```