### PR TITLE
bugs: fix castling bugs

### DIFF
--- a/src/movegen/move_generation.h
+++ b/src/movegen/move_generation.h
@@ -99,7 +99,7 @@ constexpr static inline void generateKingMoves(ValidMoves& validMoves, uint64_t 
 constexpr static inline void generateCastlingMovesWhite(ValidMoves& validMoves, const BitBoard& board, uint64_t attacks)
 {
     constexpr uint64_t queenSideAttackMask { 0x1cULL }; // 0b11100 - fields that can block castling if attacked
-    constexpr uint64_t kingSideAttackMask { 0x30ULL }; // 0b110000 - fields that can block castling if attacked
+    constexpr uint64_t kingSideAttackMask { 0x70ULL }; // 0b1110000 - fields that can block castling if attacked
     constexpr uint64_t queenSideOccupationMask { 0xeULL }; // 0b1110 - fields that can block castling if occupied
     constexpr uint64_t kingSideOccupationMask { 0x60ULL }; // 0b1100000 - fields that can block castling if occupied
 
@@ -125,7 +125,7 @@ constexpr static inline void generateCastlingMovesWhite(ValidMoves& validMoves, 
 constexpr static inline void generateCastlingMovesBlack(ValidMoves& validMoves, const BitBoard& board, uint64_t attacks)
 {
     constexpr uint64_t queenSideAttackMask { 0x1cULL << s_eightRow };
-    constexpr uint64_t kingSideAttackMask { 0x30ULL << s_eightRow };
+    constexpr uint64_t kingSideAttackMask { 0x70ULL << s_eightRow };
     constexpr uint64_t queenSideOccupationMask { 0xeULL << s_eightRow };
     constexpr uint64_t kingSideOccupationMask { 0x60ULL << s_eightRow };
 

--- a/src/parsing/fen_parser.h
+++ b/src/parsing/fen_parser.h
@@ -112,6 +112,9 @@ public:
 
         board.updateOccupation();
 
+        board.attacks[PlayerWhite] = attackgen::getAllAttacks<PlayerWhite>(board);
+        board.attacks[PlayerBlack] = attackgen::getAllAttacks<PlayerBlack>(board);
+
         return true;
     }
 


### PR DESCRIPTION
The fen parser bug was the one found on the test server:

```
[Event "?"]
[Site "?"]
[Date "2025.04.18"]
[Round "1"]
[White "Meltdown-base"]
[Black "Meltdown-dev"]
[Result "0-1"]
[FEN "r1b1k1nr/p2pp1bp/2p2pp1/q7/2B1P3/3Q4/PPP2PPP/RNB1K2R w KQkq - 0 1"]
[GameDuration "00:00:00"]
[GameEndTime "2025-04-18T12:51:12.831 CEST"]
[GameStartTime "2025-04-18T12:51:12.477 CEST"]
[PlyCount "0"]
[SetUp "1"]
[Termination "illegal move"]
[TimeControl "10.11+0.1"]

{White makes an illegal move: e1g1} 0-1
```

Quite unlikely to happen though, but still, should work.

Also, the attack mask bug *could not* happen in a game - king would be in check after the move. But no reason to generate the move (debug handles would show it as legal move).