### PR TITLE
bench: clear TT between runs

### DIFF
--- a/src/engine/bench.h
+++ b/src/engine/bench.h
@@ -14,6 +14,7 @@ public:
     static void run(uint8_t depth = s_defaultSearchDepth)
     {
         s_nodesCount = 0;
+        engine::TtHashTable::clear();
 
         using namespace std::chrono;
         const auto startTime = system_clock::now();


### PR DESCRIPTION
Previously the TT would still be occupied between runs. This meant that running a bench multiple times would generate different results. Also it would mean that bench could be "corrupted" from previous searches etc.

Bench 13598897