### PR TITLE
Add bench verification to PR checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,3 +47,19 @@ jobs:
         path: .build-tests/meson-logs/testlog.junit.xml
         reporter: java-junit
 
+  verify-bench:
+    runs-on: ubuntu-latest
+    container:
+      image: hansbinderup/meson-gcc:1.1
+      options: --user root
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+          clean: true
+          fetch-depth: 2 # action adds a merge commit on top - account for that
+    - name: Safe directory
+      run: git config --global --add safe.directory '*'
+    - name: Verify bench
+      run: scripts/verify_commit_bench.sh
+

--- a/scripts/verify_commit_bench.sh
+++ b/scripts/verify_commit_bench.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+# build for native (fastest)
+scripts/build.sh
+
+# run bench and extract nodes
+echo "running bench..."
+ENGINE_OUTPUT=$(./.build/meltdown-chess-engine bench)
+
+# openbench expects: 'xxxx nodes xxxx nps' as last line
+# extract the number in front of 'nodes' for last line
+ENGINE_NODES=$(echo $ENGINE_OUTPUT | grep -oP '\d+(?=\s+nodes)' | tail -n1 || true)
+if [ -z "$ENGINE_NODES" ]; then
+    echo "::error title=verify-bench::Failed to extract nodes from engine's bench result"
+    exit 1
+fi
+
+# Extract bench from commit message
+# Format is: Bench XXXXXXX
+# Prioritize last one if multiple are provided
+# NOTE: --no-merges is added to support 'checkout action' from github actions
+#       it adds a merge commit on top of the branch
+COMMIT_MSG=$(git log --no-merges -1 --pretty=%B)
+COMMIT_NODES=$(echo "$COMMIT_MSG" | grep -oP 'Bench \K[0-9]+' | tail -n1 || true)
+
+if [ -z "$COMMIT_NODES" ]; then
+    echo "Commit does not contain a bench"
+    echo "::error title=verify-bench::Missing 'Bench $ENGINE_NODES' in commit message"
+    exit 1
+fi
+
+# Compare bench from engine and commit message
+if [ "$ENGINE_NODES" -eq "$COMMIT_NODES" ]; then
+    echo "::notice title=verify-bench::Engine and commit bench is a match: $COMMIT_NODES"
+    exit 0
+else
+    echo "Engine and commit nodes does not match: [$ENGINE_NODES != $COMMIT_NODES]"
+    echo "::error title=verify-bench::Update 'Bench $ENGINE_NODES' in the commit message"
+    exit 1
+fi


### PR DESCRIPTION
[Example](https://github.com/hansbinderup/meltdown-chess-engine/actions/runs/14562959813?pr=58) where the commit message contains the wrong bench eg.

See commit message for more details :))

NOTE: for this to work I've enabled a setting for the repo where each branch must be up to date with main before merging. This is necessary for the bench values to reflect the value they'll have when merged to main.