### PR TITLE
tt_hash_table: add min size

### DIFF
--- a/src/engine/bench.h
+++ b/src/engine/bench.h
@@ -56,8 +56,9 @@ public:
         /* OpenBench expects this format */
         fmt::println("{} nodes {:.0f} nps", s_nodesCount, nps);
 
-        /* reset to previous size */
-        engine::TtHashTable::setSizeMb(previousHashSize);
+        if (previousHashSize > 0) {
+            engine::TtHashTable::setSizeMb(previousHashSize);
+        }
     }
 
 private:

--- a/src/engine/tt_hash_table.h
+++ b/src/engine/tt_hash_table.h
@@ -102,6 +102,11 @@ public:
      * NOTE: NOT THREAD SAFE */
     static void setSizeMb(std::size_t sizeMb)
     {
+        if (sizeMb <= 0) {
+            fmt::println("Invalid size: {}mb", sizeMb);
+            return;
+        }
+
         if (s_ttHashSize > 0) {
             helper::alignedFree(s_ttHashTable);
         }


### PR DESCRIPTION
When resetting the hash table for bench it would result in a nullptr being return from the allocator.
We should not allow setting the table to size 0. We need at least 1mb table, so set a lower limit.

Bench 14238911