### PR TITLE
tt_hash_table: correct getSizeMb

### DIFF
--- a/src/engine/bench.h
+++ b/src/engine/bench.h
@@ -15,7 +15,7 @@ public:
     {
         s_nodesCount = 0;
 
-        const size_t previousHashSize = engine::TtHashTable::getSizeMb();
+        const std::size_t previousHashSize = engine::TtHashTable::getSizeMb();
 
         /* lots of different positions - use a fairly universal size
          * FIXME: add hash size as an optional argument */

--- a/src/engine/tt_hash_table.h
+++ b/src/engine/tt_hash_table.h
@@ -124,7 +124,7 @@ public:
 
     static std::size_t getSizeMb()
     {
-        return s_ttHashSize;
+        return (s_ttHashSize / 1024 / 1024) * sizeof(TtHashEntry);
     }
 
     static void clear()


### PR DESCRIPTION
Did not return mb.. it returned the size of the table instead.

Bench 14238911