### PR TITLE
meson: add developer-build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ All binaries are statically compiled so it should be easy to run.
 1. Setup [docker](https://docs.docker.com/get-started/get-docker/)
 2. Run docker iteractively: `./docker/run.sh`
 3. Run one of the 3 build scripts:
-    * For release/optimized build: `./scripts/build.sh -r` (-r is optional and will run the compiled executable)
+    * Release build: `./scripts/build.sh --release <-r | optional: run the executable>`
+    * Development build: `./scripts/build.sh <-r | optional: run the executable>`
     * For debugging in gdb: `./scripts/debug.sh`
     * Compile and run unit-tests: `./scripts/unit_test.sh`
 

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,13 @@ add_project_arguments('-fconstexpr-ops-limit=100000000000', language: 'cpp')
 
 if get_option('buildtype') != 'debug'
   add_project_arguments('-flto=auto', '-Ofast', '-funroll-loops', '-m64', '-finline-functions',  language : 'cpp')
+
+  # allows developers to have a safer build - easier to debug with minimal runtime cost
+  if get_option('developer-build') == false
+    add_project_arguments('-DNDEBUG',  language : 'cpp')
+  endif
 endif
+
 
 # magic_enum
 magic_enum = subproject('magic_enum', default_options: ['test=false'])

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,5 @@
 option('unit-tests', type: 'boolean', value: false, description: 'Build the unit tests')
 option('ci', type: 'boolean', value: false, description: 'Build is from the CI')
 option('meltdown-version', type: 'string', value: '0.0.0-dev', description: 'Meltdown version')
+option('developer-build', type: 'boolean', value: false, description: 'Build Meltdown for development')
 option('tuning', type: 'boolean', value: false, description: 'Build Meltdown for tuning')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,20 +4,27 @@ set -e
 
 BUILD_DIR=".build"
 RUN=false
+OPTIMIZATION="dev"
+ARGS=()
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -r) RUN=true ;;
+        --release) OPTIMIZATION="release" ;;
         *) echo "Unknown option: $1" && exit 1 ;;
     esac
     shift
 done
 
+if [[ "$OPTIMIZATION" == "dev" ]]; then
+    ARGS+=("-Ddeveloper-build=true")
+fi
+
 if [ ! -d "$BUILD_DIR" ]; then
     NATIVE_TARGET=$(scripts/get-native-target.sh)
-    echo "Setting up Meson for $NATIVE_TARGET"
-    meson setup "$BUILD_DIR" --cross-file "targets/$NATIVE_TARGET" --buildtype=release
+    echo "Setting up Meson for $NATIVE_TARGET with ARGS: ${ARGS[*]}"
+    meson setup "$BUILD_DIR" --cross-file "targets/$NATIVE_TARGET" --buildtype=release "${ARGS[@]}"
 fi
 
 ln -sf "$BUILD_DIR"/compile_commands.json .


### PR DESCRIPTION
This commit adds the option to build a developer build. We have different optimization levels. We're already running an "optimized" build. BUT, we're still compiling without NDEBUG which has quite a runtime penalty.

NDEBUG should only be used for actual releases though. It's quite a comfort while developing. Therefore add a setting where we can specify developer build settings.

Bench 11349788

NOTE: I'll update the tournament script to build optimized builds. But it requires more than a few changes, so I'll leave that for now