### PR TITLE
evalutor: correct min search

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -203,11 +203,6 @@ private:
 
             m_endTime = start + adjustedTime - buffer + timeInc;
         }
-
-        /* just to make sure that we actually search something - better to run out of time than to not search any moves.. */
-        if (m_endTime <= start) {
-            m_endTime = start + milliseconds(250) + timeInc;
-        }
     };
 
     constexpr movegen::Move scanForBestMove(uint8_t depth, const BitBoard& board)
@@ -224,29 +219,32 @@ private:
 
         uint8_t d = 1;
         while (d <= depth) {
-            if (m_isStopped)
-                break;
-
-            /* always allow full scan on first move - will be good for the hash table :) */
-            if (board.fullMoves > 0) {
-                const auto now = std::chrono::system_clock::now();
-                const auto timeLeft = m_endTime - now;
-                const auto timeSpent = now - m_startTime;
-
-                /* factor is "little less than half" meaning that we give juuust about half the time we spent to search a new depth
-                 * might need tweaking - will do when game phases are implemented */
-                const auto timeLimit = timeSpent / 1.9;
-
-                /* uncommment for debugging */
-
-                /* m_logger.log("d: {}, timeLeft: {}, timeSpent: {}, timeLimit: {}", d, */
-                /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeLeft), */
-                /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent), */
-                /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeLimit)); */
-
-                if (timeLeft < timeLimit) {
-                    /* m_logger.log("Stopped early; saved: {}", std::chrono::duration_cast<std::chrono::milliseconds>(timeLeft)); */
+            /* always search at least one ply - otherwise we have no PV move */
+            if (d > 1) {
+                if (m_isStopped)
                     break;
+
+                /* always allow full scan on first move - will be good for the hash table :) */
+                if (board.fullMoves > 0) {
+                    const auto now = std::chrono::system_clock::now();
+                    const auto timeLeft = m_endTime - now;
+                    const auto timeSpent = now - m_startTime;
+
+                    /* factor is "little less than half" meaning that we give juuust about half the time we spent to search a new depth
+                     * might need tweaking - will do when game phases are implemented */
+                    const auto timeLimit = timeSpent / 1.9;
+
+                    /* uncommment for debugging */
+
+                    /* m_logger.log("d: {}, timeLeft: {}, timeSpent: {}, timeLimit: {}", d, */
+                    /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeLeft), */
+                    /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent), */
+                    /*     std::chrono::duration_cast<std::chrono::milliseconds>(timeLimit)); */
+
+                    if (timeLeft < timeLimit) {
+                        /* m_logger.log("Stopped early; saved: {}", std::chrono::duration_cast<std::chrono::milliseconds>(timeLeft)); */
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently we're adding an arbritary time bonus to avoid not having a PV move. This is adding some funky timing issues in ultra bullet where 250ms is extremely long time - compared to how long the search would otherwise search for.
Instead remove this weird time bonus and instead ensure that we at least always search one depth.

Bench 11349788