### PR TITLE
evaluation: Split evaluator into evaluator+searcher

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -1,26 +1,26 @@
 #pragma once
 
-#include "engine/move_handling.h"
 #include "engine/thread_pool.h"
 #include "engine/tt_hash_table.h"
-#include "evaluation/move_ordering.h"
-#include "evaluation/pv_table.h"
-#include "evaluation/repetition.h"
-#include "evaluation/static_evaluation.h"
+#include "evaluation/searcher.h"
+
 #include "fmt/ranges.h"
 #include "movegen/move_types.h"
-#include "syzygy/syzygy.h"
 #include <atomic>
 #include <engine/zobrist_hashing.h>
 
 #include <chrono>
 #include <mutex>
-#include <thread>
 
 namespace evaluation {
 
 class Evaluator {
 public:
+    constexpr uint64_t getNodes() const
+    {
+        return m_searcher.getNodes();
+    }
+
     constexpr movegen::Move getBestMove(const BitBoard& board, std::optional<uint8_t> depthInput = std::nullopt)
     {
         m_startTime = std::chrono::system_clock::now();
@@ -34,12 +34,9 @@ public:
             startTimeHandler();
         }
 
-        m_hash = engine::generateHashKey(board);
+        const uint64_t hash = engine::generateHashKey(board);
 
-        /* we're dependent on the hash table - ensure it's initialized! */
-        if (engine::TtHashTable::getSizeMb() == 0) {
-            engine::TtHashTable::setSizeMb(s_defaultTtHashTableSizeMb);
-        }
+        m_searcher.setHashKey(hash);
 
         return scanForBestMove(depthInput.value_or(s_maxSearchDepth), board);
     }
@@ -57,16 +54,19 @@ public:
     {
         return m_threadPool.submit([this, board, depthInput] {
             const auto move = getBestMove(board, depthInput);
+
+            if (m_killed.load(std::memory_order_relaxed))
+                return;
+
             fmt::print("bestmove {}", move);
             if (m_ponderingEnabled) {
-                const auto ponderMove = m_moveOrdering.pvTable().ponderMove();
-                if (!ponderMove.isNull()) {
-                    fmt::print(" ponder {}", ponderMove);
+                const auto ponderMove = m_searcher.getPonderMove();
+                if (ponderMove.has_value()) {
+                    fmt::print(" ponder {}", ponderMove.value());
                 }
             }
 
             fmt::println("");
-
             fflush(stdout);
         });
     }
@@ -87,66 +87,22 @@ public:
         m_ponderingEnabled = enabled;
     }
 
-    constexpr std::optional<movegen::Move> getPonderMove() const
-    {
-        if (m_moveOrdering.pvTable().size() > 1) {
-            return m_moveOrdering.pvTable()[1];
-        }
-
-        return std::nullopt;
-    }
-
-    /* TODO: ensure time handler is stopped as well - not just assumed stopped. This is racy */
-    constexpr void stop()
+    void stop()
     {
         m_isPondering = false;
-        m_isStopped = true;
+        m_isStopped.store(true, std::memory_order_relaxed);
+        Searcher::setSearchStopped(true);
     }
 
-    constexpr uint64_t getNodes() const
+    void kill()
     {
-        return m_nodes;
+        m_killed.store(true, std::memory_order_relaxed);
+        stop();
     }
 
     constexpr void printEvaluation(const BitBoard& board, std::optional<uint8_t> depthInput = std::nullopt)
     {
-        resetTiming(); /* to reset nodes etc but not tables */
-
-        uint8_t depth = depthInput.value_or(5);
-
-        fmt::println("");
-
-        movegen::ValidMoves captures;
-        engine::getAllMoves<movegen::MoveCapture>(board, captures);
-        if (captures.count()) {
-            m_moveOrdering.sortMoves(board, captures, m_ply);
-
-            fmt::print("Captures[{}]: ", captures.count());
-            for (const auto& move : captures) {
-                fmt::print("{} [{}]  ", move, m_moveOrdering.moveScore(board, move, 0));
-            }
-            fmt::print("\n\n");
-        }
-
-        /* no need for time management here - just control the start/stop ourselves */
-        m_isStopped = false;
-
-        movegen::ValidMoves moves;
-        engine::getAllMoves<movegen::MovePseudoLegal>(board, moves);
-        m_moveOrdering.sortMoves(board, moves, m_ply);
-        const int32_t score = negamax(depth, board);
-        stop();
-
-        fmt::println("Move evaluations [{}]:", depth);
-        for (const auto& move : moves) {
-            fmt::println("  {}: {}", move, m_moveOrdering.moveScore(board, move, 0));
-        }
-
-        fmt::println("\nTotal nodes:     {}\n"
-                     "Search score:    {}\n"
-                     "PV-line:         {}\n"
-                     "Static eval:     {}\n",
-            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), staticEvaluation(board));
+        m_searcher.printEvaluation(board, depthInput);
     }
 
     void setWhiteTime(uint64_t time)
@@ -191,20 +147,42 @@ public:
         m_moveTime.reset();
         m_whiteMoveInc = 0;
         m_blackMoveInc = 0;
-        m_nodes = 0;
-        m_selDepth = 0;
+
+        m_searcher.resetNodes();
     }
 
     void reset()
     {
         resetTiming(); // full reset required
-        m_moveOrdering.reset();
-        m_repetition.reset();
+        m_searcher.reset();
     }
 
     void updateRepetition(uint64_t hash)
     {
-        m_repetition.add(hash);
+        m_searcher.updateRepetition(hash);
+    }
+
+    constexpr void printScoreInfo(Searcher* searcher, const BitBoard& board, int32_t score, uint8_t currentDepth, const TimePoint& startTime)
+    {
+        using namespace std::chrono;
+
+        const auto endTime = system_clock::now();
+        const auto timeDiff = duration_cast<milliseconds>(endTime - startTime).count();
+
+        auto scoreTbHit = searcher->approxDtzScore(board, score);
+        score = scoreTbHit.first;
+        uint8_t tbHit = scoreTbHit.second;
+
+        if (score > -s_mateValue && score < -s_mateScore)
+            fmt::print("info score mate {} time {} depth {} seldepth {} nodes {} tbhits {} pv ", -(score + s_mateValue) / 2 - 1, timeDiff, currentDepth, searcher->getSelDepth(), getNodes(), tbHit);
+        else if (score > s_mateScore && score < s_mateValue)
+            fmt::print("info score mate {} time {} depth {} seldepth {} nodes {} tbhits {} pv ", (s_mateValue - score) / 2 + 1, timeDiff, currentDepth, searcher->getSelDepth(), getNodes(), tbHit);
+        else
+            fmt::print("info score cp {} time {} depth {} seldepth {} nodes {} hashfull {} tbhits {} pv ", score, timeDiff, currentDepth, searcher->getSelDepth(), getNodes(), engine::TtHashTable::getHashFull(), tbHit);
+
+        fmt::println("{}", fmt::join(searcher->getPvTable(), " "));
+
+        fflush(stdout);
     }
 
 private:
@@ -242,11 +220,10 @@ private:
 
             m_endTime = start + adjustedTime - buffer + timeInc;
         }
-    };
+    }
 
     constexpr movegen::Move scanForBestMove(uint8_t depth, const BitBoard& board)
     {
-
         int32_t alpha = s_minScore;
         int32_t beta = s_maxScore;
 
@@ -254,13 +231,13 @@ private:
          * iterative deeping - with aspiration window
          * https://web.archive.org/web/20070705134903/www.seanet.com/%7Ebrucemo/topics/aspiration.htm
          */
-
         uint8_t d = 1;
+
         while (d <= depth) {
-            /* always search at least one ply - otherwise we have no PV move */
             if (d > 1) {
-                if (m_isStopped)
+                if (m_isStopped.load(std::memory_order_relaxed)) {
                     break;
+                }
 
                 /* always allow full scan on first move - will be good for the hash table :) */
                 if (board.fullMoves > 0) {
@@ -286,13 +263,9 @@ private:
                 }
             }
 
-            m_moveOrdering.pvTable().setIsFollowing(true);
-            m_wdl = syzygy::WdlResultTableNotActive;
-            m_dtz = 0;
+            Searcher::setSearchStopped(false);
+            const int32_t score = m_searcher.startSearch(d, board, alpha, beta);
 
-            const int32_t score = negamax(d, board, alpha, beta);
-
-            /* the search fell outside the window - we need to retry a full search */
             if ((score <= alpha) || (score >= beta)) {
                 alpha = s_minScore;
                 beta = s_maxScore;
@@ -304,7 +277,7 @@ private:
             alpha = score - s_aspirationWindow;
             beta = score + s_aspirationWindow;
 
-            printScoreInfo(board, score, d);
+            printScoreInfo(&m_searcher, board, score, d, m_startTime);
 
             /* only increment depth, if we didn't fall out of the window */
             d++;
@@ -313,355 +286,21 @@ private:
         /* in case we're scanning to a certain depth we need to ensure that we're stopping the time handler */
         stop();
 
-        return m_moveOrdering.pvTable().bestMove();
-    }
-
-    constexpr void printScoreInfo(const BitBoard& board, int32_t score, uint8_t currentDepth)
-    {
-        using namespace std::chrono;
-
-        const auto endTime = system_clock::now();
-        const auto timeDiff = duration_cast<milliseconds>(endTime - m_startTime).count();
-
-        uint8_t tbHit = 0;
-        score = syzygy::approximateDtzScore(board, score, m_dtz, m_wdl, tbHit);
-
-        if (score > -s_mateValue && score < -s_mateScore)
-            fmt::print("info score mate {} time {} depth {} seldepth {} nodes {} tbhits {} pv ", -(score + s_mateValue) / 2 - 1, timeDiff, currentDepth, m_selDepth, m_nodes, tbHit);
-        else if (score > s_mateScore && score < s_mateValue)
-            fmt::print("info score mate {} time {} depth {} seldepth {} nodes {} tbhits {} pv ", (s_mateValue - score) / 2 + 1, timeDiff, currentDepth, m_selDepth, m_nodes, tbHit);
-        else
-            fmt::print("info score cp {} time {} depth {} seldepth {} nodes {} hashfull {} tbhits {} pv ", score, timeDiff, currentDepth, m_selDepth, m_nodes, engine::TtHashTable::getHashFull(), tbHit);
-
-        fmt::println("{}", fmt::join(m_moveOrdering.pvTable(), " "));
-
-        fflush(stdout);
-    }
-
-    enum SearchType {
-        Default,
-        NullSearch,
-    };
-
-    template<SearchType searchType = SearchType::Default>
-    constexpr int32_t negamax(uint8_t depth, const BitBoard& board, int32_t alpha = s_minScore, int32_t beta = s_maxScore)
-    {
-        const bool isRoot = m_ply == 0;
-
-        m_moveOrdering.pvTable().updateLength(m_ply);
-        if (m_ply) {
-            /* FIXME: make a little more sophisticated with material count etc */
-            const bool isDraw = m_repetition.isRepetition(m_hash) || board.halfMoves >= 100;
-            if (isDraw)
-                return 0; /* draw score */
-        }
-
-        const bool isPv = beta - alpha > 1;
-        const auto hashProbe = engine::TtHashTable::probe(m_hash, depth, m_ply);
-        if (hashProbe.has_value() && m_ply && !isPv) {
-            if ((hashProbe->flag == engine::TtHashExact)
-                || (hashProbe->flag == engine::TtHashAlpha && hashProbe->score <= alpha)
-                || (hashProbe->flag == engine::TtHashBeta && hashProbe->score >= beta)) {
-                return hashProbe->score;
-            }
-        }
-
-        // Engine is not designed to search deeper than this! Make sure to stop before it's too late
-        if (m_ply >= s_maxSearchDepth) {
-            return staticEvaluation(board);
-        }
-
-        const bool isChecked = engine::isKingAttacked(board);
-        if (isChecked) {
-            /* Dangerous position - increase search depth
-             * NOTE: there's rarely many legal moves in this position
-             * so it's quite cheap to extend the search a bit */
-            depth++;
-        }
-
-        if (depth == 0) {
-            return quiesence(board, alpha, beta);
-        }
-
-        m_nodes++;
-
-        /* entries for the TT hash */
-        engine::TtHashFlag hashFlag = engine::TtHashAlpha;
-        movegen::Move alphaMove {};
-
-        uint32_t legalMoves = 0;
-        uint64_t movesSearched = 0;
-
-        const int32_t staticEval = staticEvaluation(board);
-
-        /* https://www.chessprogramming.org/Reverse_Futility_Pruning */
-        if (depth < s_reductionLimit && !isPv && !isChecked) {
-            const bool withinFutilityMargin = abs(beta - 1) > (s_minScore + s_futilityMargin);
-            const int32_t evalMargin = s_futilityEvaluationMargin * depth;
-
-            if (withinFutilityMargin && (staticEval - evalMargin) >= beta)
-                return staticEval - evalMargin;
-        }
-
-        /* dangerous to repeat null search on a null search - skip it here */
-        if constexpr (searchType != SearchType::NullSearch) {
-            if (depth > s_nullMoveReduction && !isChecked && m_ply) {
-                if (const auto nullMoveScore = nullMovePruning(board, depth, beta)) {
-                    return nullMoveScore.value();
-                }
-            }
-        }
-
-        /* https://www.chessprogramming.org/Razoring (Strelka) */
-        if (!isPv && !isChecked && depth <= s_reductionLimit) {
-            int32_t score = staticEval + s_razorMarginShallow;
-            if (score < beta) {
-                if (depth == 1) {
-                    int32_t newScore = quiesence(board, alpha, beta);
-                    return (newScore > score) ? newScore : score;
-                }
-
-                score += s_razorMarginDeep;
-                if (score < beta && depth <= s_razorDeepReductionLimit) {
-                    const int32_t newScore = quiesence(board, alpha, beta);
-                    if (newScore < beta)
-                        return (newScore > score) ? newScore : score;
-                }
-            }
-        }
-
-        bool tbMoves = false;
-        movegen::ValidMoves moves {};
-        if (syzygy::isTableActive(board)) {
-            if (isRoot) {
-                tbMoves = syzygy::generateSyzygyMoves(board, moves, m_wdl, m_dtz);
-            } else if (board.isQuietPosition()) {
-                int32_t score = 0;
-                syzygy::probeWdl(board, score);
-                engine::TtHashTable::writeEntry(m_hash, score, movegen::Move {}, s_maxSearchDepth, m_ply, engine::TtHashExact);
-                return score;
-            }
-        }
-
-        if (!tbMoves) {
-            engine::getAllMoves<movegen::MovePseudoLegal>(board, moves);
-
-            if (m_moveOrdering.pvTable().isFollowing()) {
-                m_moveOrdering.pvTable().updatePvScoring(moves, m_ply);
-            }
-
-            const auto ttMove = hashProbe.has_value() ? std::make_optional(hashProbe->move) : std::nullopt;
-            m_moveOrdering.sortMoves(board, moves, m_ply, ttMove);
-        }
-
-        for (const auto& move : moves) {
-            const auto moveRes = makeMove(board, move);
-            if (!moveRes.has_value()) {
-                continue;
-            }
-
-            int32_t score = 0;
-            legalMoves++;
-
-            /*
-             * LMR
-             * https://wiki.sharewiz.net/doku.php?id=chess:programming:late_move_reduction
-             */
-            if (movesSearched == 0) {
-                score = -negamax(depth - 1, moveRes->board, -beta, -alpha);
-            } else {
-                if (movesSearched >= s_fullDepthMove
-                    && depth >= s_reductionLimit
-                    && !isChecked
-                    && !move.isCapture()
-                    && !move.isPromotionMove()) {
-                    /* search current move with reduced depth */
-                    score = -negamax(depth - 2, moveRes->board, -alpha - 1, -alpha);
-                } else {
-                    /* TODO: hack to ensure full depth is reached */
-                    score = alpha + 1;
-                }
-
-                /*
-                 * PVS
-                 * https://en.wikipedia.org/wiki/Principal_variation_search
-                 * search with a null window
-                 */
-                if (score > alpha) {
-                    score = -negamax(depth - 1, moveRes->board, -alpha - 1, -alpha);
-
-                    /* if it failed high, do a full re-search */
-                    if ((score > alpha) && (score < beta)) {
-                        score = -negamax(depth - 1, moveRes->board, -beta, -alpha);
-                    }
-                }
-            }
-
-            undoMove(moveRes->hash);
-
-            if (m_isStopped)
-                return score;
-
-            if (score >= beta) {
-                engine::TtHashTable::writeEntry(m_hash, score, move, depth, m_ply, engine::TtHashBeta);
-                m_moveOrdering.killerMoves().update(move, m_ply);
-                return beta;
-            }
-
-            movesSearched++;
-            if (score > alpha) {
-                alpha = score;
-
-                hashFlag = engine::TtHashExact;
-                alphaMove = move;
-
-                m_moveOrdering.historyMoves().update(board, move, m_ply);
-                m_moveOrdering.pvTable().updateTable(move, m_ply);
-            }
-        }
-
-        if (legalMoves == 0) {
-            if (isChecked) {
-                // We want absolute negative score - but with amount of moves to the given checkmate
-                // we add the ply to make checkmate in less moves a better move
-                return -s_mateValue + m_ply;
-            } else {
-                // Stalemate - absolute neutral score
-                return 0;
-            }
-        }
-
-        engine::TtHashTable::writeEntry(m_hash, alpha, alphaMove, depth, m_ply, hashFlag);
-        return alpha;
-    }
-
-    constexpr int32_t quiesence(const BitBoard& board, int32_t alpha, int32_t beta)
-    {
-        using namespace std::chrono;
-
-        m_nodes++;
-        m_selDepth = std::max(m_selDepth, m_ply);
-
-        const int32_t evaluation = staticEvaluation(board);
-
-        if (m_ply >= s_maxSearchDepth)
-            return evaluation;
-
-        // Hard cutoff
-        if (evaluation >= beta) {
-            return beta;
-        }
-
-        if (evaluation > alpha) {
-            alpha = evaluation;
-        }
-
-        movegen::ValidMoves moves;
-        engine::getAllMoves<movegen::MoveCapture>(board, moves);
-        m_moveOrdering.sortMoves(board, moves, m_ply);
-
-        for (const auto& move : moves) {
-            const auto moveRes = makeMove(board, move);
-            if (!moveRes.has_value()) {
-                continue;
-            }
-
-            const int32_t score = -quiesence(moveRes->board, -beta, -alpha);
-            undoMove(moveRes->hash);
-
-            if (m_isStopped)
-                return score;
-
-            if (score >= beta)
-                // change to beta for hard cutoff
-                return beta;
-
-            if (score > alpha) {
-                alpha = score;
-            }
-        }
-
-        return alpha;
-    }
-
-    /*
-     * null move pruning
-     * https://www.chessprogramming.org/Null_Move_Pruning
-     * */
-    std::optional<int32_t> nullMovePruning(const BitBoard& board, uint8_t depth, int32_t beta)
-    {
-        auto nullMoveBoard = board;
-        uint64_t oldHash = m_hash;
-        if (nullMoveBoard.enPessant.has_value())
-            engine::hashEnpessant(nullMoveBoard.enPessant.value(), m_hash);
-
-        engine::hashPlayer(m_hash);
-
-        /* enPessant is invalid if we skip move */
-        nullMoveBoard.enPessant.reset();
-
-        /* give opponent an extra move */
-        nullMoveBoard.player = nextPlayer(nullMoveBoard.player);
-
-        m_ply += 2;
-        m_repetition.add(oldHash);
-
-        /* perform search with reduced depth (based on reduction limit) */
-        int32_t score = -negamax<SearchType::NullSearch>(depth - 1 - s_nullMoveReduction, nullMoveBoard, -beta, -beta + 1);
-
-        m_hash = oldHash;
-        m_ply -= 2;
-        m_repetition.remove();
-
-        if (score >= beta) {
-            return beta;
-        }
-
-        return std::nullopt;
-    }
-
-    struct MoveResult {
-        uint64_t hash;
-        BitBoard board;
-    };
-
-    std::optional<MoveResult> makeMove(const BitBoard& board, const movegen::Move& move)
-    {
-        const MoveResult res { m_hash, engine::performMove(board, move, m_hash) };
-
-        if (engine::isKingAttacked(res.board, board.player)) {
-            m_hash = res.hash;
-
-            // invalid move
-            return std::nullopt;
-        }
-
-        m_repetition.add(res.hash);
-        m_ply++;
-
-        return res;
-    }
-
-    void undoMove(uint64_t hash)
-    {
-        m_hash = hash;
-
-        m_repetition.remove();
-        m_ply--;
+        return m_searcher.getPvMove();
     }
 
     void startTimeHandler()
     {
-        /* we only have two slots - so if we can't start the thread then it must already be running */
+        /* we only have three slots - so if we can't start the thread then it must already be running */
         std::ignore = m_threadPool.submit([this] {
-            while (!m_isStopped) {
+            while (!m_isStopped.load(std::memory_order_relaxed)) {
                 {
                     std::scoped_lock lock(m_timeHandleMutex);
-                    if (m_isStopped)
+                    if (m_isStopped.load(std::memory_order_relaxed))
                         return; /* stopped elsewhere */
 
                     if (std::chrono::system_clock::now() > m_endTime) {
-                        m_isStopped = true;
+                        stop();
                     }
                 }
 
@@ -670,17 +309,10 @@ private:
         });
     }
 
-    uint64_t m_nodes {};
-    uint8_t m_ply {};
+    Searcher m_searcher {};
+
     std::atomic_bool m_isStopped { true };
-    uint64_t m_hash {};
-    uint8_t m_selDepth {};
-
-    syzygy::WdlResult m_wdl = syzygy::WdlResultTableNotActive;
-    uint8_t m_dtz {};
-
-    MoveOrdering m_moveOrdering {};
-    Repetition m_repetition;
+    std::atomic_bool m_killed { false };
 
     uint64_t m_whiteTime {};
     uint64_t m_blackTime {};
@@ -693,21 +325,11 @@ private:
     TimePoint m_endTime;
     std::mutex m_timeHandleMutex;
 
-    ThreadPool m_threadPool { 2 }; /* searcher and time handler */
+    ThreadPool m_threadPool { 2 }; /* Search and time handler */
     bool m_isPondering { false };
     bool m_ponderingEnabled { false };
 
-    /* search configs */
-    constexpr static inline uint32_t s_fullDepthMove { 4 };
-    constexpr static inline uint32_t s_reductionLimit { 3 };
-    constexpr static inline int32_t s_futilityMargin { 100 };
-    constexpr static inline int32_t s_futilityEvaluationMargin { 120 };
-    constexpr static inline int32_t s_razorMarginShallow { 125 };
-    constexpr static inline int32_t s_razorMarginDeep { 175 };
-    constexpr static inline uint8_t s_razorDeepReductionLimit { 2 };
     constexpr static inline uint32_t s_defaultAmountMoves { 75 };
-
     constexpr static inline uint8_t s_aspirationWindow { 50 };
-    constexpr static inline uint8_t s_nullMoveReduction { 2 };
 };
 }

--- a/src/evaluation/searcher.h
+++ b/src/evaluation/searcher.h
@@ -1,0 +1,483 @@
+#pragma once
+
+#include "engine/move_handling.h"
+#include "engine/thread_pool.h"
+#include "engine/tt_hash_table.h"
+#include "evaluation/move_ordering.h"
+#include "evaluation/pv_table.h"
+#include "evaluation/repetition.h"
+#include "evaluation/static_evaluation.h"
+
+#include "fmt/ranges.h"
+#include "movegen/move_types.h"
+#include "syzygy/syzygy.h"
+#include <atomic>
+#include <engine/zobrist_hashing.h>
+
+namespace evaluation {
+
+enum SearchType {
+    Default,
+    NullSearch,
+};
+
+struct MoveResult {
+    uint64_t hash;
+    BitBoard board;
+};
+
+class Searcher;
+
+class Searcher {
+public:
+    Searcher() = default;
+
+    void setHashKey(uint64_t hash)
+    {
+        m_hash = hash;
+    }
+
+    constexpr uint64_t getNodes() const
+    {
+        return m_nodes;
+    }
+
+    constexpr uint8_t getSelDepth() const
+    {
+        return m_selDepth;
+    }
+
+    static constexpr void setSearchStopped(bool value)
+    {
+        s_searchStopped.store(value, std::memory_order_relaxed);
+    }
+
+    int32_t inline startSearch(uint8_t depth, const BitBoard& board, int32_t alpha, int32_t beta)
+    {
+        m_moveOrdering.pvTable().setIsFollowing(true);
+        m_wdl = syzygy::WdlResultTableNotActive;
+        m_dtz = 0;
+
+        return negamax(depth, board, alpha, beta);
+    }
+
+    constexpr movegen::Move getPvMove() const
+    {
+        return m_moveOrdering.pvTable().bestMove();
+    }
+
+    constexpr std::optional<movegen::Move> getPonderMove() const
+    {
+        const auto ponderMove = m_moveOrdering.pvTable().ponderMove();
+        return ponderMove.isNull() ? std::nullopt : std::make_optional(ponderMove);
+    }
+
+    void resetNodes()
+    {
+        m_nodes = 0;
+        m_selDepth = 0;
+    }
+
+    void reset()
+    {
+        m_moveOrdering.reset();
+        m_repetition.reset();
+        resetNodes();
+
+        m_wdl = syzygy::WdlResultTableNotActive;
+        m_dtz = 0;
+
+        m_board.reset();
+        m_hash = 0;
+    }
+
+    void updateRepetition(uint64_t hash)
+    {
+        m_repetition.add(hash);
+    }
+
+    constexpr std::pair<int32_t, uint8_t> approxDtzScore(const BitBoard& board, int32_t score)
+    {
+        uint8_t tbHit = 0;
+        score = syzygy::approximateDtzScore(board, score, m_dtz, m_wdl, tbHit);
+        return { score, tbHit };
+    }
+
+    constexpr auto& getPvTable() const
+    {
+        return m_moveOrdering.pvTable();
+    }
+
+    constexpr void printEvaluation(const BitBoard& board, std::optional<uint8_t> depthInput = std::nullopt)
+    {
+        resetNodes(); /* to reset nodes etc but not tables */
+
+        uint8_t depth = depthInput.value_or(5);
+
+        fmt::println("");
+
+        movegen::ValidMoves captures;
+        engine::getAllMoves<movegen::MoveCapture>(board, captures);
+        if (captures.count()) {
+            m_moveOrdering.sortMoves(board, captures, m_ply);
+
+            fmt::print("Captures[{}]: ", captures.count());
+            for (const auto& move : captures) {
+                fmt::print("{} [{}]  ", move, m_moveOrdering.moveScore(board, move, 0));
+            }
+            fmt::print("\n\n");
+        }
+
+        /* no need for time management here - just control the start/stop ourselves */
+        s_searchStopped.store(false, std::memory_order_relaxed);
+
+        movegen::ValidMoves moves;
+        engine::getAllMoves<movegen::MovePseudoLegal>(board, moves);
+        m_moveOrdering.sortMoves(board, moves, m_ply);
+        const int32_t score = negamax(depth, board);
+        s_searchStopped.store(true, std::memory_order_relaxed);
+
+        fmt::println("Move evaluations [{}]:", depth);
+        for (const auto& move : moves) {
+            fmt::println("  {}: {}", move, m_moveOrdering.moveScore(board, move, 0));
+        }
+
+        fmt::println("\nTotal nodes:     {}\n"
+                     "Search score:    {}\n"
+                     "PV-line:         {}\n"
+                     "Static eval:     {}\n",
+            m_nodes, score, fmt::join(m_moveOrdering.pvTable(), " "), staticEvaluation(board));
+    }
+
+    template<SearchType searchType = SearchType::Default>
+    constexpr int32_t negamax(uint8_t depth, const BitBoard& board, int32_t alpha = s_minScore, int32_t beta = s_maxScore)
+    {
+        const bool isRoot = m_ply == 0;
+
+        m_moveOrdering.pvTable().updateLength(m_ply);
+        if (m_ply) {
+            /* FIXME: make a little more sophisticated with material count etc */
+            const bool isDraw = m_repetition.isRepetition(m_hash) || board.halfMoves >= 100;
+            if (isDraw)
+                return 0; /* draw score */
+        }
+
+        const bool isPv = beta - alpha > 1;
+        const auto hashProbe = engine::TtHashTable::probe(m_hash, depth, m_ply);
+        if (hashProbe.has_value() && m_ply && !isPv) {
+            if ((hashProbe->flag == engine::TtHashExact)
+                || (hashProbe->flag == engine::TtHashAlpha && hashProbe->score <= alpha)
+                || (hashProbe->flag == engine::TtHashBeta && hashProbe->score >= beta)) {
+                return hashProbe->score;
+            }
+        }
+
+        // Engine is not designed to search deeper than this! Make sure to stop before it's too late
+        if (m_ply >= s_maxSearchDepth) {
+            return staticEvaluation(board);
+        }
+
+        const bool isChecked = engine::isKingAttacked(board);
+        if (isChecked) {
+            /* Dangerous position - increase search depth
+             * NOTE: there's rarely many legal moves in this position
+             * so it's quite cheap to extend the search a bit */
+            depth++;
+        }
+
+        if (depth == 0) {
+            return quiesence(board, alpha, beta);
+        }
+
+        m_nodes++;
+
+        /* entries for the TT hash */
+        engine::TtHashFlag hashFlag = engine::TtHashAlpha;
+        movegen::Move alphaMove {};
+
+        uint32_t legalMoves = 0;
+        uint64_t movesSearched = 0;
+
+        const int32_t staticEval = staticEvaluation(board);
+
+        /* https://www.chessprogramming.org/Reverse_Futility_Pruning */
+        if (depth < s_reductionLimit && !isPv && !isChecked) {
+            const bool withinFutilityMargin = abs(beta - 1) > (s_minScore + s_futilityMargin);
+            const int32_t evalMargin = s_futilityEvaluationMargin * depth;
+
+            if (withinFutilityMargin && (staticEval - evalMargin) >= beta)
+                return staticEval - evalMargin;
+        }
+
+        /* dangerous to repeat null search on a null search - skip it here */
+        if constexpr (searchType != SearchType::NullSearch) {
+            if (depth > s_nullMoveReduction && !isChecked && m_ply) {
+                if (const auto nullMoveScore = nullMovePruning(board, depth, beta)) {
+                    return nullMoveScore.value();
+                }
+            }
+        }
+
+        /* https://www.chessprogramming.org/Razoring (Strelka) */
+        if (!isPv && !isChecked && depth <= s_reductionLimit) {
+            int32_t score = staticEval + s_razorMarginShallow;
+            if (score < beta) {
+                if (depth == 1) {
+                    int32_t newScore = quiesence(board, alpha, beta);
+                    return (newScore > score) ? newScore : score;
+                }
+
+                score += s_razorMarginDeep;
+                if (score < beta && depth <= s_razorDeepReductionLimit) {
+                    const int32_t newScore = quiesence(board, alpha, beta);
+                    if (newScore < beta)
+                        return (newScore > score) ? newScore : score;
+                }
+            }
+        }
+
+        bool tbMoves = false;
+        movegen::ValidMoves moves {};
+        if (syzygy::isTableActive(board)) {
+            if (isRoot) {
+                tbMoves = syzygy::generateSyzygyMoves(board, moves, m_wdl, m_dtz);
+            } else if (board.isQuietPosition()) {
+                int32_t score = 0;
+                syzygy::probeWdl(board, score);
+                engine::TtHashTable::writeEntry(m_hash, score, movegen::Move {}, s_maxSearchDepth, m_ply, engine::TtHashExact);
+                return score;
+            }
+        }
+
+        if (!tbMoves) {
+            engine::getAllMoves<movegen::MovePseudoLegal>(board, moves);
+
+            if (m_moveOrdering.pvTable().isFollowing()) {
+                m_moveOrdering.pvTable().updatePvScoring(moves, m_ply);
+            }
+
+            const auto ttMove = hashProbe.has_value() ? std::make_optional(hashProbe->move) : std::nullopt;
+            m_moveOrdering.sortMoves(board, moves, m_ply, ttMove);
+        }
+
+        for (const auto& move : moves) {
+            const auto moveRes = makeMove(board, move);
+            if (!moveRes.has_value()) {
+                continue;
+            }
+
+            int32_t score = 0;
+            legalMoves++;
+
+            /*
+             * LMR
+             * https://wiki.sharewiz.net/doku.php?id=chess:programming:late_move_reduction
+             */
+            if (movesSearched == 0) {
+                score = -negamax(depth - 1, moveRes->board, -beta, -alpha);
+            } else {
+                if (movesSearched >= s_fullDepthMove
+                    && depth >= s_reductionLimit
+                    && !isChecked
+                    && !move.isCapture()
+                    && !move.isPromotionMove()) {
+                    /* search current move with reduced depth */
+                    score = -negamax(depth - 2, moveRes->board, -alpha - 1, -alpha);
+                } else {
+                    /* TODO: hack to ensure full depth is reached */
+                    score = alpha + 1;
+                }
+
+                /*
+                 * PVS
+                 * https://en.wikipedia.org/wiki/Principal_variation_search
+                 * search with a null window
+                 */
+                if (score > alpha) {
+                    score = -negamax(depth - 1, moveRes->board, -alpha - 1, -alpha);
+
+                    /* if it failed high, do a full re-search */
+                    if ((score > alpha) && (score < beta)) {
+                        score = -negamax(depth - 1, moveRes->board, -beta, -alpha);
+                    }
+                }
+            }
+
+            undoMove(moveRes->hash);
+
+            if (s_searchStopped.load(std::memory_order_relaxed))
+                return score;
+
+            if (score >= beta) {
+                engine::TtHashTable::writeEntry(m_hash, score, move, depth, m_ply, engine::TtHashBeta);
+                m_moveOrdering.killerMoves().update(move, m_ply);
+                return beta;
+            }
+
+            movesSearched++;
+            if (score > alpha) {
+                alpha = score;
+
+                hashFlag = engine::TtHashExact;
+                alphaMove = move;
+
+                m_moveOrdering.historyMoves().update(board, move, m_ply);
+                m_moveOrdering.pvTable().updateTable(move, m_ply);
+            }
+        }
+
+        if (legalMoves == 0) {
+            if (isChecked) {
+                // We want absolute negative score - but with amount of moves to the given checkmate
+                // we add the ply to make checkmate in less moves a better move
+                return -s_mateValue + m_ply;
+            } else {
+                // Stalemate - absolute neutral score
+                return 0;
+            }
+        }
+
+        engine::TtHashTable::writeEntry(m_hash, alpha, alphaMove, depth, m_ply, hashFlag);
+        return alpha;
+    }
+
+private:
+    constexpr int32_t quiesence(const BitBoard& board, int32_t alpha, int32_t beta)
+    {
+        using namespace std::chrono;
+
+        m_nodes++;
+        m_selDepth = std::max(m_selDepth, m_ply);
+
+        const int32_t evaluation = staticEvaluation(board);
+
+        if (m_ply >= s_maxSearchDepth)
+            return evaluation;
+
+        // Hard cutoff
+        if (evaluation >= beta) {
+            return beta;
+        }
+
+        if (evaluation > alpha) {
+            alpha = evaluation;
+        }
+
+        movegen::ValidMoves moves;
+        engine::getAllMoves<movegen::MoveCapture>(board, moves);
+        m_moveOrdering.sortMoves(board, moves, m_ply);
+
+        for (const auto& move : moves) {
+            const auto moveRes = makeMove(board, move);
+            if (!moveRes.has_value()) {
+                continue;
+            }
+
+            const int32_t score = -quiesence(moveRes->board, -beta, -alpha);
+            undoMove(moveRes->hash);
+
+            if (s_searchStopped.load(std::memory_order_relaxed))
+                return score;
+
+            if (score >= beta)
+                // change to beta for hard cutoff
+                return beta;
+
+            if (score > alpha) {
+                alpha = score;
+            }
+        }
+
+        return alpha;
+    }
+
+    /*
+     * null move pruning
+     * https://www.chessprogramming.org/Null_Move_Pruning
+     * */
+    std::optional<int32_t> nullMovePruning(const BitBoard& board, uint8_t depth, int32_t beta)
+    {
+        auto nullMoveBoard = board;
+        uint64_t oldHash = m_hash;
+        if (nullMoveBoard.enPessant.has_value())
+            engine::hashEnpessant(nullMoveBoard.enPessant.value(), m_hash);
+
+        engine::hashPlayer(m_hash);
+
+        /* enPessant is invalid if we skip move */
+        nullMoveBoard.enPessant.reset();
+
+        /* give opponent an extra move */
+        nullMoveBoard.player = nextPlayer(nullMoveBoard.player);
+
+        m_ply += 2;
+        m_repetition.add(oldHash);
+
+        /* perform search with reduced depth (based on reduction limit) */
+        int32_t score = -negamax<SearchType::NullSearch>(depth - 1 - s_nullMoveReduction, nullMoveBoard, -beta, -beta + 1);
+
+        m_hash = oldHash;
+        m_ply -= 2;
+        m_repetition.remove();
+
+        if (score >= beta) {
+            return beta;
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<MoveResult> makeMove(const BitBoard& board, const movegen::Move& move)
+    {
+        const MoveResult res { m_hash, engine::performMove(board, move, m_hash) };
+
+        if (engine::isKingAttacked(res.board, board.player)) {
+            m_hash = res.hash;
+
+            // invalid move
+            return std::nullopt;
+        }
+
+        m_repetition.add(res.hash);
+        m_ply++;
+
+        return res;
+    }
+
+    void undoMove(uint64_t hash)
+    {
+        m_hash = hash;
+
+        m_repetition.remove();
+        m_ply--;
+    }
+
+    static inline uint8_t s_numSearchers {};
+
+    static inline std::atomic_bool s_searchStopped { true };
+
+    uint64_t m_nodes {};
+    uint8_t m_ply {};
+    Repetition m_repetition;
+    MoveOrdering m_moveOrdering {};
+    uint8_t m_selDepth {};
+
+    syzygy::WdlResult m_wdl { syzygy::WdlResultTableNotActive };
+    uint8_t m_dtz {};
+
+    BitBoard m_board;
+    uint64_t m_hash;
+
+    /* search configs */
+    constexpr static inline uint32_t s_fullDepthMove { 4 };
+    constexpr static inline uint32_t s_reductionLimit { 3 };
+    constexpr static inline int32_t s_futilityMargin { 100 };
+    constexpr static inline int32_t s_futilityEvaluationMargin { 120 };
+    constexpr static inline int32_t s_razorMarginShallow { 125 };
+    constexpr static inline int32_t s_razorMarginDeep { 175 };
+    constexpr static inline uint8_t s_razorDeepReductionLimit { 2 };
+
+    constexpr static inline uint8_t s_nullMoveReduction { 2 };
+};
+
+}

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -29,6 +29,7 @@ public:
         startInputThread();
 
         /* always release resources */
+        s_evaluator.stop();
         syzygy::deinit();
     }
 
@@ -80,7 +81,7 @@ private:
         } else if (command == "version") {
             return handleVersion();
         } else if (command == "quit" || command == "exit") {
-            s_isRunning = false;
+            return handleQuit();
         } else {
             // invalid input
             return false;
@@ -229,6 +230,14 @@ private:
         return true;
     }
 
+    static bool handleQuit()
+    {
+        s_evaluator.kill();
+        s_isRunning = false;
+
+        return true;
+    }
+
     static bool handleSetOption(std::string_view input)
     {
         const auto name = parsing::sv_next_split(input);
@@ -340,6 +349,7 @@ private:
     static inline bool s_isRunning = false;
     static inline BitBoard s_board {};
     static inline evaluation::Evaluator s_evaluator;
+
     constexpr static inline std::size_t s_inputBufferSize { 2048 };
 
     /* UCI options callbacks */
@@ -361,4 +371,3 @@ private:
         ucioption::make<ucioption::spin>("Hash", s_defaultTtHashTableSizeMb, ucioption::Limits { .min = 1, .max = 1024 }, [](uint64_t val) { engine::TtHashTable::setSizeMb(val); }),
     });
 };
-

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Scoring", "[scoring]")
 
             movegen::ValidMoves moves;
             engine::getAllMoves<movegen::MoveCapture>(*board, moves);
-            s_evaluator.m_moveOrdering.sortMoves(board.value(), moves, 0);
+            s_evaluator.m_searcher.m_moveOrdering.sortMoves(board.value(), moves, 0);
 
             REQUIRE(moves.count() == 3);
             REQUIRE(moves[0].piece() == WhitePawn);
@@ -66,7 +66,7 @@ TEST_CASE("Scoring", "[scoring]")
 
             movegen::ValidMoves moves;
             engine::getAllMoves<movegen::MovePseudoLegal>(*board, moves);
-            s_evaluator.m_moveOrdering.sortMoves(board.value(), moves, 0);
+            s_evaluator.m_searcher.m_moveOrdering.sortMoves(board.value(), moves, 0);
 
             REQUIRE(moves[0].piece() == WhitePawn);
             REQUIRE(moves[1].piece() == WhiteKing);
@@ -77,4 +77,3 @@ TEST_CASE("Scoring", "[scoring]")
         }
     }
 }
-


### PR DESCRIPTION
Evaluator was getting so large it was becoming unwieldy, so this commit splits it into an evaluator (time control, iterative deepening) and a searcher (search and heuristics).

The searcher's early return on e.g. a stop() call is handled by a separate flag to the evaluator's. This clarifies ownership and looks toward the multi-threading scenario of multiple searchers.

Bench 11349788