### PR TITLE
time_manager: fix printing on stop()

### DIFF
--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -174,7 +174,8 @@ private:
             alpha = score - s_aspirationWindow;
             beta = score + s_aspirationWindow;
 
-            printScoreInfo(&m_searcher, board, score, d);
+            if (TimeManager::timeForAnotherSearch(board))
+                printScoreInfo(&m_searcher, board, score, d);
 
             /* only increment depth, if we didn't fall out of the window */
             d++;


### PR DESCRIPTION
New time manager added a bug where upon calling stop(), an extra `printScoreInfo` call happened, printing an empty PV line.

This happened when `stop` command was entered mid-search. Search terminates and PV is not updated. But it gets printed anyway.

This commit wraps printing with an additional check for the stopped condition, fixing the bug.