### PR TITLE
bench: pass evaluator instead of self ownning

### DIFF
--- a/src/engine/bench.h
+++ b/src/engine/bench.h
@@ -11,11 +11,9 @@ namespace engine {
 
 class Bench {
 public:
-    static void run(uint8_t numSearchers, uint8_t depth = s_defaultSearchDepth)
+    static void run(evaluation::Evaluator& evaluator, uint8_t depth = s_defaultSearchDepth)
     {
         s_nodesCount = 0;
-
-        s_evaluator.resizeSearchers(numSearchers);
 
         const std::size_t previousHashSize = engine::TtHashTable::getSizeMb();
 
@@ -37,10 +35,10 @@ public:
 
             fmt::println("Position {}/{} [{}]", ++count, s_benchPositions.size(), position);
 
-            s_evaluator.reset();
-            const auto bestMove = s_evaluator.getBestMove(*board, depth);
+            evaluator.reset();
+            const auto bestMove = evaluator.getBestMove(*board, depth);
 
-            s_nodesCount += s_evaluator.getNodes();
+            s_nodesCount += evaluator.getNodes();
 
             fmt::println("bestmove {}\n", bestMove);
         }
@@ -65,8 +63,6 @@ public:
 
 private:
     static inline uint64_t s_nodesCount {};
-    static inline evaluation::Evaluator s_evaluator;
-
     constexpr static inline uint8_t s_defaultSearchDepth { 8 };
 
     /* commonly used bench positions */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,8 @@ int main(int argc, char** argv)
     const auto args = std::span(argv, argc);
     for (const auto arg : args) {
         if (std::strcmp(arg, "bench") == 0) {
-            engine::Bench::run(1);
+            evaluation::Evaluator evaluator {};
+            engine::Bench::run(evaluator);
             return 0;
         }
     }

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -309,9 +309,9 @@ private:
     {
         const auto depth = parsing::to_number(args);
         if (depth.has_value()) {
-            engine::Bench::run(s_numSearchers, *depth);
+            engine::Bench::run(s_evaluator, *depth);
         } else {
-            engine::Bench::run(s_numSearchers);
+            engine::Bench::run(s_evaluator);
         }
 
         return true;


### PR DESCRIPTION
Now that we have thread pools we don't need to allocate threads just for a "debug/testing handle".
Instead we can just pass an evaluator and let the consumer have ownership instead.

This has a few extra benefits:
1. No extra threads running
2. Thread count will automatically be updated (no need to pass args etc)
3. Less memory allocated

Bench 11349788