### PR TITLE
tt_hash_table: add prefetch

### DIFF
--- a/src/engine/move_handling.h
+++ b/src/engine/move_handling.h
@@ -2,6 +2,7 @@
 
 #include "attack_generation.h"
 #include "bit_board.h"
+#include "engine/tt_hash_table.h"
 #include "engine/zobrist_hashing.h"
 #include "helpers/formatters.h"
 #include "movegen/move_generation.h"
@@ -244,6 +245,9 @@ constexpr BitBoard performMove(const BitBoard& board, const movegen::Move& move,
 
     newBoard.player = nextPlayer(player);
     hashPlayer(hash);
+
+    /* prefetch as soon as we have calculated the key/hash */
+    engine::TtHashTable::prefetch(hash);
 
     return newBoard;
 }

--- a/src/engine/tt_hash_table.h
+++ b/src/engine/tt_hash_table.h
@@ -57,6 +57,13 @@ public:
         clear();
     }
 
+    /* prefetches the memory and loads it into L1 cache line */
+    constexpr static void prefetch([[maybe_unused]] uint64_t key)
+    {
+        assert(s_ttHashSize > 0);
+        __builtin_prefetch(&s_ttHashTable[key % s_ttHashSize]);
+    }
+
     static std::size_t getSizeMb()
     {
         return (s_ttHashSize / 1024 / 1024) * sizeof(TtHashEntry);

--- a/tests/src/test_move_gen_hashing.cpp
+++ b/tests/src/test_move_gen_hashing.cpp
@@ -27,6 +27,7 @@ void testAllMoves(const BitBoard& board, uint8_t depth = s_defaultSearchDepth)
 
 TEST_CASE("Movegen Hashing", "[movegen]")
 {
+    engine::TtHashTable::setSizeMb(16);
 
     SECTION("Test from start position")
     {

--- a/tests/src/test_perft.cpp
+++ b/tests/src/test_perft.cpp
@@ -8,6 +8,8 @@
 
 TEST_CASE("Perft", "[perft]")
 {
+    engine::TtHashTable::setSizeMb(16);
+
     BitBoard board;
     board.reset();
 


### PR DESCRIPTION
This commit adds support for prefetching transposition table entries.

One downside of having a larger table is the increased risk of cache misses during lookups. To mitigate this, we issue a prefetch instruction to bring the relevant memory into the cache ahead of time.

Bench 11029400

```
Elo   | 5.52 +- 4.13 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=128MB
Games | N: 10004 W: 3520 L: 3361 D: 3123
Penta | [261, 687, 2977, 786, 291]
https://openbench.bunny.beer/test/85/
```