### PR TITLE
evaluation: add variance to draw score

### DIFF
--- a/src/evaluation/searcher.h
+++ b/src/evaluation/searcher.h
@@ -197,8 +197,12 @@ public:
         if (m_ply) {
             /* FIXME: make a little more sophisticated with material count etc */
             const bool isDraw = m_repetition.isRepetition(m_hash) || board.halfMoves >= 100;
-            if (isDraw)
-                return 0; /* draw score */
+            if (isDraw) {
+                /* draw score is 0 but to avoid blindness towards three fold lines
+                 * we add a slight variance to the draw score
+                 * it will still be approx 0~ cp: [-0.1:0.1] */
+                return 1 - (m_nodes & 2); /* draw score */
+            }
         }
 
         const bool isPv = beta - alpha > 1;


### PR DESCRIPTION
Previously the draw score was "0". This is also theoretically correct. But in terms of pruning it can cause some issues as we might actually find a three fold line that win us the game.
So this is an attempt at reducing the draw blindness towards such lines.

Bench 11044213

```
Elo   | 2.94 +- 9.73 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=8MB
Games | N: 2008 W: 678 L: 661 D: 669
Penta | [51, 179, 546, 158, 70]
https://openbench.bunny.beer/test/87/
```