### PR TITLE
uci_handler: correct engine id name

### DIFF
--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -95,8 +95,9 @@ private:
 
     static bool handleUci()
     {
-        fmt::println("id engine Meltdown\n"
-                     "id author Hans Binderup");
+        fmt::println("id name Meltdown {}\n"
+                     "id author Hans Binderup",
+            s_meltdownVersion);
 
         for (const auto& option : s_uciOptions) {
             ucioption::printInfo(option);


### PR DESCRIPTION
Previously the engine name was provided under "id engine". This is incorrect as the engine name should be provided as "id name".

Also added version number to make versioning clear during tournaments.

Bench 11029400