### PR TITLE
uci_handler: correct threads option

### DIFF
--- a/src/board_defs.h
+++ b/src/board_defs.h
@@ -141,5 +141,6 @@ constexpr static inline Score s_mateScore { s_mateValue - 1000 };
 constexpr static inline std::size_t s_defaultTtHashTableSizeMb { 16 };
 
 constexpr static inline uint8_t s_middleGamePhase { 24 };
+constexpr static inline size_t s_maxThreads { 128 };
 
 using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;

--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -22,14 +22,12 @@ public:
         resizeSearchers(1);
     };
 
-    void resizeSearchers(uint8_t size)
+    void resizeSearchers(size_t size)
     {
         if (size == m_searchers.size()) {
             return;
-        }
-
-        else {
-            for (uint8_t i = m_searchers.size(); i < size; i++) {
+        } else {
+            for (size_t i = m_searchers.size(); i < size; i++) {
                 m_searchers.emplace_back(std::make_unique<Searcher>());
             }
         }
@@ -178,8 +176,6 @@ public:
 
         fflush(stdout);
     }
-
-    constexpr static inline uint8_t s_maxThreads { 128 };
 
 private:
     constexpr movegen::Move scanForBestMove(uint8_t depth, const BitBoard& board)

--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -350,7 +350,6 @@ private:
     static inline bool s_isRunning = false;
     static inline BitBoard s_board {};
     static inline evaluation::Evaluator s_evaluator;
-    static inline uint8_t s_numSearchers { 1 };
 
     constexpr static inline std::size_t s_inputBufferSize { 2048 };
 
@@ -371,8 +370,7 @@ private:
         ucioption::make<ucioption::check>("Ponder", false, [](bool enabled) { s_evaluator.setPondering(enabled); }),
         ucioption::make<ucioption::string>("Syzygy", "<empty>", syzygyCallback),
         ucioption::make<ucioption::spin>("Hash", s_defaultTtHashTableSizeMb, ucioption::Limits { .min = 1, .max = 1024 }, [](uint64_t val) { engine::TtHashTable::setSizeMb(val); }),
-        ucioption::make<ucioption::spin>("Threads", 1, ucioption::Limits { .min = 1, .max = 256 }, [](uint64_t val) {
-            s_numSearchers = val;
+        ucioption::make<ucioption::spin>("Threads", 1, ucioption::Limits { .min = 1, .max = s_maxThreads }, [](uint64_t val) {
             s_evaluator.resizeSearchers(val);
         }),
     });


### PR DESCRIPTION
This commit fixes overflows and incorrect buffer size for searchers.

Prior to this commit it was possible to add "256" threads; uint8_t would overflow and the search result array was limited to 128 (local constant).

Bench 11029400