### PR TITLE
uci_handler: increase input buffer size to fix crashes

### DIFF
--- a/src/uci_handler.h
+++ b/src/uci_handler.h
@@ -351,7 +351,9 @@ private:
     static inline BitBoard s_board {};
     static inline evaluation::Evaluator s_evaluator;
 
-    constexpr static inline std::size_t s_inputBufferSize { 2048 };
+    /* 1024 bytes -> 200~ plys
+     * aim to support around 1000 plys of moves + a buffer to be sure */
+    constexpr static inline std::size_t s_inputBufferSize { 1024 * 6 };
 
     /* UCI options callbacks */
     static inline void syzygyCallback(std::string_view path)


### PR DESCRIPTION
In the openbench tests I've seen the engine crash every now and then. I noticed that all the crashes happened when we were 400~ ply deep. This lead to me checking the input buffer for overflowing.

Using the follow uci command:

```
position startpos moves e2e4 e7e5 g1f3 b8c6 f1b5 a7a6 b5a4 g8f6 e1g1 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 f3h4 e7f8 h4f3 f8e7 d2d3 d7d6 c1e3 c8e6 b1c3 b8a6 e8d7
```

would crash the engine.
Therefore scale the buffer to fit at least 1000 plies (what the rest of the engine is scaled for).

Bench 12443446

Info from test server:
![image](https://github.com/user-attachments/assets/0b75ac68-50cb-44e1-b357-25e0eb9ed820)

EG:
```
[Event "?"]
[Site "?"]
[Date "2025.05.08"]
[Round "1"]
[White "Meltdown-base"]
[Black "Meltdown-dev"]
[Result "0-1"]
[FEN "r3kb1r/pp1n1pp1/1qp1bp2/3p3p/3P4/1P1BPQ2/P1P1NPPP/RN2K2R w KQkq - 0 1"]
[GameDuration "00:00:53"]
[GameEndTime "2025-05-08T01:17:09.606 UTC"]
[GameStartTime "2025-05-08T01:16:15.821 UTC"]
[PlyCount "392"]
[SetUp "1"]
[Termination "abandoned"]
[TimeControl "9.71+0.1"]

1. O-O {-0.04 8/19 271 221307} O-O-O {-0.01 8/21 460 360788}
2. h3 {0.00 8/19 338 285196} h4 {+0.06 8/25 596 472903}
3. Nf4 {+0.16 9/24 716 611110} Bd6 {-0.11 8/22 405 341713}
4. Nxe6 {+0.21 9/21 453 417554} fxe6 {0.00 8/18 280 233702}
5. Qg4 {+0.33 9/22 888 796044} e5 {-0.20 8/20 565 437274}
6. c3 {+0.21 8/19 315 276500} e4 {-0.23 8/19 405 315536}
7. Be2 {+0.05 9/25 457 387111} g5 {-0.09 7/18 204 156839}
8. Nd2 {0.00 9/24 612 531121} Qc7 {-0.10 7/23 208 157233}
9. a4 {+0.17 8/22 353 302866} a5 {-0.24 8/21 519 409822}
10. Qf5 {+0.16 8/22 202 185061} Kb8 {-0.46 7/21 200 154672}
11. Kh1 {+0.07 7/21 189 166561} Rh6 {-0.05 7/22 214 177145}
12. Rg1 {-0.10 7/18 169 147060} Nb6 {+0.05 7/20 165 121524}
13. Rac1 {-0.15 7/22 247 197594} Qc8 {+0.26 9/22 591 460714}
14. Qxc8+ {-0.28 8/20 169 156537} Rxc8 {+0.40 8/23 166 137551}
15. c4 {-0.13 9/22 239 229152} Bb4 {+0.29 9/20 278 257144}
16. Rgd1 {-0.06 9/20 212 197015} dxc4 {+0.11 9/19 246 218934}
17. Nxc4 {-0.03 10/19 318 308438} Nxc4 {+0.10 10/20 275 258630}
18. Bxc4 {-0.10 10/18 188 188718} f5 {+0.29 10/19 288 273697}
19. Kh2 {-0.22 9/19 180 171572} Rd8 {+0.30 9/20 227 201249}
20. Rc2 {-0.28 9/19 237 225271} Ka7 {+0.47 9/18 210 184971}
21. Kg1 {-0.47 9/18 284 263883} Rf6 {+0.60 9/18 141 128990}
22. Kh2 {-0.51 9/18 141 140755} f4 {+0.60 9/19 146 134573}
23. Kg1 {-0.57 9/18 385 344311} f3 {+0.57 9/21 224 203143}
24. Rdc1 {-0.56 9/17 146 134745} g4 {+0.96 9/16 129 124881}
25. hxg4 {-0.92 9/18 154 159282} Rg6 {+0.74 10/20 195 196921}
26. Kh2 {-0.69 9/19 107 109402} Rxg4 {+0.66 9/19 148 149500}
27. Rg1 {-0.66 9/19 182 189437} Ba3 {+0.79 9/21 180 194693}
28. gxf3 {-0.60 9/18 134 136151} Rxg1 {+0.36 11/19 125 148467}
29. Kxg1 {-0.22 11/17 99 113083} exf3 {+0.22 11/18 147 163175}
30. Kh2 {+0.14 11/19 138 157007} Re8 {-0.07 10/17 128 138664}
31. Kh3 {+0.30 11/18 228 241444} Be7 {-0.25 10/20 281 290286}
32. Kg4 {+0.24 9/16 96 104656} Rh8 {+0.21 9/16 119 115568}
33. Kxf3 {-0.02 10/19 180 191263} h3 {-0.15 10/19 189 187169}
34. Rc1 {+0.06 9/18 120 126406} Bd6 {-0.09 9/18 129 124245}
35. Rh1 {+0.27 10/18 166 175146} h2 {-0.17 9/17 147 141012}
36. Ke4 {+0.39 9/19 153 156186} Kb6 {-0.34 9/20 211 202883}
37. f4 {+0.39 9/18 98 96479} Rh3 {-0.54 10/20 746 687086}
38. f5 {+0.33 8/16 173 160310} Be7 {-0.34 9/17 134 119598}
39. Bf1 {+0.53 9/17 187 188561} Rh8 {-0.52 9/18 234 210525}
40. Kf3 {+0.55 9/17 172 167133} Bd6 {-0.58 9/17 143 139191}
41. Bc4 {+0.68 9/17 140 133662} Rh3+ {-0.80 8/18 212 185483}
42. Kf2 {+0.75 7/16 83 82143} c5 {-0.97 9/18 176 161139}
43. dxc5+ {+0.99 10/20 194 181272} Kxc5 {-1.04 9/17 149 142791}
44. f6 {+1.14 10/17 103 95858} Rh5 {-1.02 9/16 97 86135}
45. f7 {+1.14 9/16 84 76171} Kb4 {-1.16 9/17 216 191818}
46. Ke2 {+1.25 9/16 112 109596} Rh3 {-1.07 8/15 101 93859}
47. Be6 {+1.13 9/17 113 111708} Rh5 {-0.96 9/17 139 132338}
48. Kd3 {+1.08 9/17 117 109749} Bc5 {-1.01 8/15 84 75981}
49. Ke4 {+1.09 8/18 78 75387} b6 {-0.86 8/17 76 70891}
50. Kf4 {+1.08 9/18 204 196632} Bd6+ {-1.10 8/17 77 75648}
51. Kf3 {+1.19 8/18 111 100044} Rh6 {-1.10 9/17 221 196550}
52. Bd5 {+1.18 8/16 76 72655} Rh3+ {-1.05 8/17 87 73562}
53. Kf2 {+1.04 7/16 131 122017} Rh5 {-1.09 8/15 64 57454}
54. e4 {+1.22 8/15 81 74810} Rh8 {-1.26 8/16 207 189037}
55. Kf3 {+1.63 9/17 187 177826} Rc8 {-1.70 8/16 132 121577}
56. Kg4 {+1.87 9/17 113 110466} Rh8 {-2.02 8/16 60 58975}
57. Kf5 {+1.94 9/18 131 115217} Kc5 {-1.74 8/16 86 73595}
58. Bc4 {+2.05 9/18 295 263094} Rh5+ {-1.69 8/18 87 74008}
59. Kg6 {+2.23 8/16 87 76114} Rh8 {-1.61 9/17 80 69037}
60. Kf6 {+2.08 8/16 123 31197} Rh6+ {-1.64 9/17 107 92093}
61. Kg7 {+1.55 8/16 76 68559} Rh3 {-1.53 9/17 147 130328}
62. Bd5 {+1.29 8/16 86 71893} Rg3+ {-1.22 8/17 68 57415}
63. Kf6 {+1.16 7/15 91 79305} Rg1 {-1.54 10/19 78 79023}
64. f8=Q {+1.42 10/18 83 86579} Bxf8 {-1.44 10/19 100 94292}
65. Rxh2 {+1.43 9/17 83 73884} Bg7+ {-1.46 9/18 309 266234}
66. Ke6 {+1.45 8/19 108 95604} Rg6+ {-1.48 8/16 78 65144}
67. Ke7 {+1.44 7/17 81 66940} Bc3 {-1.42 8/17 138 121302}
68. Rh5 {+1.44 8/16 89 79927} Kd4 {-1.66 8/15 108 101409}
69. Kf7 {+1.73 8/16 158 153154} Rd6 {-1.73 8/15 64 55642}
70. Rh3 {+1.62 9/16 92 83315} Bb2 {-1.60 8/15 124 110279}
71. Rh2 {+1.61 8/18 167 141956} Bc3 {-1.54 9/15 63 55849}
72. Rh8 {+1.60 9/16 130 112646} Kd3 {-1.43 8/14 57 50719}
73. Rh3+ {+1.49 8/16 77 65848} Kd4 {-1.52 7/17 134 109963}
74. Rf3 {+1.50 8/15 98 83780} Rh6 {-1.47 9/16 73 69972}
75. Rf5 {+1.44 8/16 70 62830} Bb4 {-1.50 8/15 74 68234}
76. Rf1 {+1.47 8/15 108 98268} Bc5 {-1.42 8/14 75 65940}
77. Rg1 {+1.43 8/14 77 70823} Bd6 {-1.51 8/15 119 101875}
78. Kg7 {+1.30 8/16 78 71637} Rh3 {-1.42 9/17 129 114793}
79. Rd1+ {+1.33 7/15 76 66871} Ke5 {-1.42 7/15 181 154820}
80. Rf1 {+1.39 9/16 107 91904} Kd4 {-1.36 9/16 69 56577}
81. Kf7 {+1.26 9/17 103 82209} Be5 {-1.25 9/17 163 144941}
82. Ke7 {+1.28 9/15 101 82634} Rh6 {-1.22 8/16 78 56841}
83. Kd7 {+1.23 8/16 97 74799} Rg6 {-1.39 8/15 138 115556}
84. Rf8 {+1.33 8/14 75 61920} Rh6 {-1.41 8/15 66 55071}
85. Rg8 {+1.30 8/16 107 88542} Ke3 {-1.23 8/16 95 80616}
86. Re8 {+1.25 8/16 106 98767} Rd6+ {-1.31 8/15 88 84931}
87. Kc8 {+1.34 8/16 89 83687} Kf4 {-1.35 8/16 73 68930}
88. Kb7 {+1.27 8/15 82 72562} Bd4 {-1.34 9/17 140 132187}
89. Rg8 {+1.30 10/17 208 208905} Rf6 {-1.42 9/15 64 54124}
90. Rh8 {+1.26 9/17 139 134134} Rg6 {-1.35 8/16 113 95855}
91. Rh5 {+1.33 8/18 69 58716} b5 {-1.44 8/16 106 96804}
92. axb5 {+1.43 9/17 127 115853} Rb6+ {-1.34 9/18 76 66431}
93. Kc7 {+1.33 9/19 178 157215} Rxb5 {-1.69 9/16 87 79388}
94. Kd6 {+1.29 8/17 80 61526} Rb6+ {-1.57 7/16 85 73602}
95. Kd7 {+1.35 7/15 69 54848} Rf6 {-1.42 9/18 101 96768}
96. Ke7 {+1.30 9/17 244 216680} Bc3 {-1.57 8/13 87 81364}
97. Rh4+ {+1.39 8/17 97 86777} Ke5 {-1.41 8/16 119 113835}
98. Kd7 {+1.37 9/16 171 140280} Kd4 {-1.32 8/15 69 55811}
99. Rg4 {+1.31 8/16 107 91741} Bb4 {-1.31 8/15 96 87569}
100. Rg1 {+1.35 8/17 80 73959} Rh6 {-1.33 7/14 99 79258}
101. Rd1+ {+1.35 8/16 108 92001} Ke5 {-1.36 8/15 87 79354}
102. Rf1 {+1.32 9/16 124 114201} Rg6 {-1.30 8/16 174 152080}
103. Rc1 {+1.33 8/16 120 107410} Rh6 {-1.32 8/15 137 121245}
104. Rc8 {+1.38 9/16 114 102053} Kd4 {-1.38 8/15 69 62157}
105. Kc7 {+1.37 8/14 64 53191} Ke3 {-1.33 8/15 125 108234}
106. Rg8 {+1.30 8/15 146 122985} Bc3 {-1.36 7/14 80 70188}
107. Rg3+ {+1.30 8/16 161 135990} Kd4 {-1.33 6/14 58 49819}
108. Kd7 {+1.28 8/14 63 52925} Bb4 {-1.34 9/16 128 103340}
109. Rg8 {+1.26 8/14 79 60646} Kd3 {-1.30 8/14 108 83595}
110. Ra8 {+1.27 7/14 64 55707} Ke3 {-1.34 8/15 164 127736}
111. Re8 {+1.20 8/15 181 150253} Bc3 {-1.32 8/17 147 122089}
112. Ke7 {+1.30 8/15 141 124970} Bd4 {-1.35 7/15 85 76334}
113. Ra8 {+1.25 9/18 173 153226} Bc3 {-1.23 8/15 65 55877}
114. Rg8 {+1.26 8/16 66 53461} Bd4 {-1.16 8/18 138 113941}
115. Kd7 {+1.31 8/15 66 53807} Rh1 {-1.30 8/15 118 102335}
116. Ra8 {+1.35 8/15 76 64809} Bc3 {-1.33 8/14 72 60578}
117. Rc8 {+1.28 8/15 100 85625} Bd4 {-1.32 9/15 193 163753}
118. Re8 {+1.30 8/14 58 49396} Bc3 {-1.34 8/15 72 61151}
119. Kc6 {+1.33 7/14 59 49359} Kd4 {-1.39 8/15 149 130765}
120. Rg8 {+1.40 8/14 94 81338} Rh6+ {-1.34 8/15 74 56727}
121. Kb5 {+1.31 8/16 180 152757} Rh1 {-1.35 8/15 66 54240}
122. Kb6 {+1.24 7/14 68 50109} Rh2 {-1.33 7/13 72 54329}
123. Rc8 {+1.28 7/13 77 59281} Rf2 {-1.35 7/14 72 63301}
124. Re8 {+1.27 8/14 175 146044} Rc2 {-1.33 8/14 86 74987}
125. Bc4 {+1.39 9/16 109 105194} Rg2 {-1.60 8/14 100 90511}
126. e5 {+1.61 8/14 62 61548} a4 {-1.54 8/15 55 50037}
127. Rd8+ {+1.57 8/17 81 75354} Kxe5 {-1.54 8/17 121 111393}
128. bxa4 {+1.61 8/16 140 107542} Bd4+ {-1.58 8/16 85 63505}
129. Kb5 {+1.61 7/15 67 52648} Rb2+ {-1.61 8/15 93 76064}
130. Kc6 {+1.65 8/17 189 148352} Rb6+ {-1.58 8/16 63 53711}
131. Kc7 {+1.76 8/17 151 110759} Rb4 {-1.65 8/16 121 95808}
132. Bb5 {+1.70 9/16 101 83199} Rb2 {-1.72 7/14 57 46648}
133. Rg8 {+1.82 7/13 88 66221} Kf4 {-1.82 7/12 65 54094}
134. Bc6 {+1.75 8/14 112 88195} Ra2 {-1.68 7/14 64 54081}
135. Kd6 {+1.70 7/13 62 46150} Be5+ {-1.68 8/16 156 115425}
136. Ke6 {+1.69 7/15 69 59709} Bd4 {-1.72 8/14 72 58292}
137. Kd5 {+1.83 8/15 86 64916} Rd2 {-1.80 7/14 66 51512}
138. Kd6 {+1.75 7/14 66 50550} Be5+ {-1.69 8/16 205 162198}
139. Ke7 {+1.82 7/14 149 118029} Bd4 {-1.64 8/14 171 130817}
140. a5 {+2.31 8/14 62 51524} Ra2 {-2.37 7/13 61 50971}
141. Ra8 {+2.56 8/14 81 70892} Bc5+ {-2.60 7/16 99 88827}
142. Kf7 {+2.71 8/15 149 121881} Bd4 {-2.77 8/14 88 74604}
143. a6 {+2.64 8/14 82 69413} Ra5 {-2.67 8/15 72 65841}
144. Bb7 {+2.63 7/15 59 56263} Re5 {-2.75 7/14 69 54327}
145. Re8 {+3.01 8/16 93 66686} Rf5+ {-2.95 8/14 112 93998}
146. Ke6 {+2.98 7/15 73 51392} Ra5 {-2.93 8/13 73 61767}
147. Kd7 {+2.91 8/13 75 62573} Kg3 {-2.99 8/15 139 107312}
148. Re6 {+3.00 7/14 74 61493} Kf2 {-2.96 8/13 91 68852}
149. Be4 {+2.90 7/12 67 55682} Ke3 {-2.87 8/14 76 64218}
150. Ke7 {+2.89 8/14 127 99063} Kd2 {-2.88 8/14 116 93780}
151. Kf7 {+2.91 8/14 93 74204} Rg5 {-2.83 8/13 103 78226}
152. Bg6 {+2.85 8/13 78 65836} Rg1 {-2.92 9/16 227 200647}
153. Ke7 {+2.90 9/15 97 77000} Ra1 {-2.91 8/15 126 101409}
154. Kd7 {+2.91 9/14 107 89266} Ra2 {-2.88 8/14 64 52248}
155. Be4 {+2.90 8/13 75 63258} Ra5 {-2.86 8/13 66 52124}
156. Bg2 {+2.87 9/15 141 115844} Kc3 {-2.92 8/15 128 100002}
157. Rc6+ {+2.90 9/14 64 55993} Kd3 {-2.94 7/13 54 49821}
158. Kd6 {+2.91 9/16 80 64155} Rg5 {-2.88 10/18 187 159853}
159. Bd5 {+2.83 9/15 95 78303} Rg1 {-2.92 8/16 66 52302}
160. Rc8 {+2.90 8/15 106 82220} Ke3 {-2.89 8/14 78 59708}
161. Re8+ {+2.88 8/15 104 81374} Kd3 {-2.90 9/16 214 167379}
162. Be4+ {+2.88 8/17 108 85063} Ke3 {-2.89 7/14 112 84219}
163. Re6 {+2.87 8/13 111 95462} Ra1 {-2.92 9/15 67 54759}
164. Bf5+ {+2.88 9/17 291 231421} Kf2 {-2.91 7/15 131 107338}
165. Ke7 {+2.88 8/12 58 43170} Rc1 {-2.89 8/12 56 45762}
166. Be4 {+2.91 8/15 74 58487} Ke3 {-2.89 8/14 100 73625}
167. Bd5+ {+2.88 9/16 117 85504} Kd3 {-2.91 8/16 54 37646}
168. Kd6 {+2.84 9/15 87 69406} Ra1 {-2.92 8/15 82 61346}
169. Kd7 {+2.84 9/15 64 43097} Rg1 {-2.90 9/16 216 161031}
170. Rh6 {+2.86 9/16 121 88059} Ke3 {-2.88 8/13 74 59791}
171. Rh1 {+2.84 8/16 135 105204} Rg7+ {-2.92 7/14 79 62069}
172. Kc6 {+3.04 7/15 181 141920} Ra7 {-2.95 7/14 55 41543}
173. Bc4 {+2.90 8/15 112 87490} Rg7 {-2.95 8/16 167 130341}
174. Kd6 {+2.94 7/14 53 45158} Kd2 {-2.95 7/13 88 69005}
175. Rh2+ {+3.01 8/15 103 81625} Kc3 {-2.84 7/14 55 42646}
176. Bd5 {+2.88 8/15 143 102474} Rg6+ {-2.90 7/14 58 44343}
177. Be6 {+2.96 8/17 96 78929} Rg1 {-2.90 8/14 55 47968}
178. Rh7 {+2.88 8/15 72 57333} Ra1 {-2.86 8/16 122 100565}
179. Rc7+ {+2.88 9/16 71 52602} Kd3 {-2.87 8/16 102 80850}
180. Bc4+ {+2.83 8/14 97 77923} Kc3 {-2.91 6/14 58 43721}
181. Rc8 {+2.90 8/14 68 50485} Rg1 {-2.89 8/15 120 84421}
182. Kd5 {+2.84 8/15 173 133965} Ba7 {-2.92 7/15 81 59287}
183. Ke6 {+2.84 8/15 134 97034} Bd4 {-2.91 8/15 115 82911}
184. Bd5+ {+2.90 8/17 72 53201} Kd2 {-2.88 8/16 87 66555}
185. Kd7 {+2.88 8/14 54 39431} Kd3 {-2.87 9/14 105 74417}
186. Bc4+ {+2.88 8/16 135 91048} Kc2 {-2.87 7/14 73 54300}
187. Rg8 {+2.88 8/12 69 55291} Ra1 {-2.89 8/13 76 58490}
188. Rg6 {+2.87 8/12 67 49017} Kc3 {-2.84 9/14 79 60248}
189. Rc6 {+2.83 8/13 260 16816} Rg1 {-1.10 8/14 100 77857}
190. Bf7+ {+0.68 7/13 70 58333} Kd2 {-0.58 7/15 60 45944}
191. Bg6 {+0.42 8/12 76 63312} Ke2 {0.00 9/16 76 63344}
192. Ke7 {0.00 9/17 57 51780} Be3 {0.00 10/18 83 68005}
193. a7 {0.00 9/17 100 81061} Bxa7 {-0.03 9/17 140 125349}
194. Bh5+ {0.00 8/17 140 104295} Kd3 {0.00 8/17 294 277662}
195. Bg6+ {0.00 9/17 67 66114} Ke3 {+0.01 8/16 89 78623}
196. Re6+ {0.00 8/16 59 49110} Kf2 {+0.01 7/16 80 60286, White disconnects} 0-1
```