### PR TITLE
movegen: scale moves to fit in 16bits instead of 32bit

### DIFF
--- a/src/engine/move_handling.h
+++ b/src/engine/move_handling.h
@@ -41,7 +41,7 @@ constexpr void performCastleMove(BitBoard& board, const movegen::Move& move, uin
     const BoardPosition fromPos = move.fromPos();
     const BoardPosition toPos = move.toPos();
 
-    switch (move.castleType()) {
+    switch (move.castleType(board.player)) {
     case CastleWhiteKingSide: {
         movePiece(board.pieces[WhiteKing], fromPos, toPos, WhiteKing, hash);
         movePiece(board.pieces[WhiteRook], H1, F1, WhiteRook, hash);
@@ -190,6 +190,7 @@ constexpr BitBoard performMove(const BitBoard& board, const movegen::Move& move,
 
     const auto fromPos = move.fromPos();
     const auto toPos = move.toPos();
+    const auto pieceType = board.getAttackerAtSquare<player>(move.fromSquare()).value();
 
     if (move.isCastleMove()) {
         performCastleMove(newBoard, move, hash);
@@ -210,7 +211,6 @@ constexpr BitBoard performMove(const BitBoard& board, const movegen::Move& move,
             }
         }
 
-        const auto pieceType = move.piece();
         movePiece(newBoard.pieces[pieceType], fromPos, toPos, pieceType, hash);
     }
 
@@ -224,7 +224,7 @@ constexpr BitBoard performMove(const BitBoard& board, const movegen::Move& move,
         hashEnpessant(board.enPessant.value(), hash);
     }
 
-    if (move.hasEnPessant()) {
+    if (move.isDoublePush()) {
         newBoard.enPessant = enpessantCapturePosition<player>(toPos);
         hashEnpessant(newBoard.enPessant.value(), hash);
     }
@@ -238,7 +238,7 @@ constexpr BitBoard performMove(const BitBoard& board, const movegen::Move& move,
     if constexpr (player == PlayerBlack)
         newBoard.fullMoves++;
 
-    if (move.isCapture() || move.piece() == WhitePawn || move.piece() == BlackPawn)
+    if (move.isCapture() || pieceType == WhitePawn || pieceType == BlackPawn)
         newBoard.halfMoves = 0;
     else
         newBoard.halfMoves++;

--- a/src/engine/tt_hash_table.h
+++ b/src/engine/tt_hash_table.h
@@ -17,7 +17,8 @@ enum TtHashFlag : uint8_t {
     TtHashBeta = 2,
 };
 
-struct TtHashEntryData {
+/* fixme: remove alignas when entry is 8 bytes */
+struct alignas(8) TtHashEntryData {
     uint8_t depth;
     TtHashFlag flag;
     Score score;

--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -59,7 +59,8 @@ public:
     {
         if (move.isCastleMove()) {
             return 0;
-        } else if (move.hasEnPessant()) {
+        } else if (move.isDoublePush()) {
+            /* FIXME: should be take enpessant? */
             return 100; /* Pawn takes pawn, so give it pawn score - anything else is difficult to handle here */
         }
 
@@ -79,7 +80,7 @@ public:
         std::array<int32_t, 32> gain {}; // Stores gains for each exchange depth
 
         /* piece that will track the scoring of next piece */
-        Piece nextPiece = move.piece();
+        Piece nextPiece = board.getAttackerAtSquare(move.fromSquare(), board.player).value();
 
         Player player = board.player;
 

--- a/src/movegen/move_generation.h
+++ b/src/movegen/move_generation.h
@@ -15,7 +15,7 @@ namespace movegen {
 namespace {
 
 template<MoveType type>
-constexpr static inline void generateKnightMoves(ValidMoves& validMoves, uint64_t knights, uint64_t ownOccupation, uint64_t theirOccupation, Piece piece)
+constexpr static inline void generateKnightMoves(ValidMoves& validMoves, uint64_t knights, uint64_t ownOccupation, uint64_t theirOccupation)
 {
     helper::bitIterate(knights, [&](BoardPosition from) {
         uint64_t moves = getKnightMoves(from) & ~ownOccupation;
@@ -23,17 +23,17 @@ constexpr static inline void generateKnightMoves(ValidMoves& validMoves, uint64_
         helper::bitIterate(moves, [&](BoardPosition pos) {
             const bool isCapture = helper::positionToSquare(pos) & theirOccupation;
             if constexpr (type == MovePseudoLegal) {
-                validMoves.addMove(Move::create(from, pos, piece, isCapture));
+                validMoves.addMove(Move::create(from, pos, isCapture));
             } else if constexpr (type == MoveCapture) {
                 if (isCapture)
-                    validMoves.addMove(Move::create(from, pos, piece, isCapture));
+                    validMoves.addMove(Move::create(from, pos, isCapture));
             }
         });
     });
 }
 
 template<MoveType type>
-constexpr static inline void generateRookMoves(ValidMoves& validMoves, uint64_t rooks, uint64_t ownOccupation, uint64_t theirOccupation, Piece piece)
+constexpr static inline void generateRookMoves(ValidMoves& validMoves, uint64_t rooks, uint64_t ownOccupation, uint64_t theirOccupation)
 {
     helper::bitIterate(rooks, [&](BoardPosition from) {
         uint64_t moves = getRookMoves(from, ownOccupation | theirOccupation) & ~ownOccupation;
@@ -42,17 +42,17 @@ constexpr static inline void generateRookMoves(ValidMoves& validMoves, uint64_t 
             const bool isCapture = helper::positionToSquare(to) & theirOccupation;
 
             if constexpr (type == MovePseudoLegal) {
-                validMoves.addMove(Move::create(from, to, piece, isCapture));
+                validMoves.addMove(Move::create(from, to, isCapture));
             } else if constexpr (type == MoveCapture) {
                 if (isCapture)
-                    validMoves.addMove(Move::create(from, to, piece, isCapture));
+                    validMoves.addMove(Move::create(from, to, isCapture));
             }
         });
     });
 }
 
 template<MoveType type>
-constexpr static inline void generateBishopMoves(ValidMoves& validMoves, uint64_t bishops, uint64_t ownOccupation, uint64_t theirOccupation, Piece piece)
+constexpr static inline void generateBishopMoves(ValidMoves& validMoves, uint64_t bishops, uint64_t ownOccupation, uint64_t theirOccupation)
 {
     helper::bitIterate(bishops, [&](BoardPosition from) {
         uint64_t moves = getBishopMoves(from, ownOccupation | theirOccupation) & ~ownOccupation;
@@ -61,24 +61,24 @@ constexpr static inline void generateBishopMoves(ValidMoves& validMoves, uint64_
             const bool isCapture = helper::positionToSquare(to) & theirOccupation;
 
             if constexpr (type == MovePseudoLegal) {
-                validMoves.addMove(Move::create(from, to, piece, isCapture));
+                validMoves.addMove(Move::create(from, to, isCapture));
             } else if constexpr (type == MoveCapture) {
                 if (isCapture)
-                    validMoves.addMove(Move::create(from, to, piece, isCapture));
+                    validMoves.addMove(Move::create(from, to, isCapture));
             }
         });
     });
 }
 
 template<MoveType type>
-constexpr static inline void generateQueenMoves(ValidMoves& validMoves, uint64_t queens, uint64_t ownOccupation, uint64_t theirOccupation, Piece piece)
+constexpr static inline void generateQueenMoves(ValidMoves& validMoves, uint64_t queens, uint64_t ownOccupation, uint64_t theirOccupation)
 {
-    generateRookMoves<type>(validMoves, queens, ownOccupation, theirOccupation, piece);
-    generateBishopMoves<type>(validMoves, queens, ownOccupation, theirOccupation, piece);
+    generateRookMoves<type>(validMoves, queens, ownOccupation, theirOccupation);
+    generateBishopMoves<type>(validMoves, queens, ownOccupation, theirOccupation);
 }
 
 template<MoveType type>
-constexpr static inline void generateKingMoves(ValidMoves& validMoves, uint64_t king, uint64_t ownOccupation, uint64_t theirOccupation, Piece piece, uint64_t attacks)
+constexpr static inline void generateKingMoves(ValidMoves& validMoves, uint64_t king, uint64_t ownOccupation, uint64_t theirOccupation, uint64_t attacks)
 {
     helper::bitIterate(king, [&](BoardPosition from) {
         uint64_t moves = s_kingsTable.at(from) & ~ownOccupation & ~attacks;
@@ -87,10 +87,10 @@ constexpr static inline void generateKingMoves(ValidMoves& validMoves, uint64_t 
             const bool isCapture = helper::positionToSquare(to) & theirOccupation;
 
             if constexpr (type == MovePseudoLegal) {
-                validMoves.addMove(Move::create(from, to, piece, isCapture));
+                validMoves.addMove(Move::create(from, to, isCapture));
             } else if constexpr (type == MoveCapture) {
                 if (isCapture)
-                    validMoves.addMove(Move::create(from, to, piece, isCapture));
+                    validMoves.addMove(Move::create(from, to, isCapture));
             }
         });
     });
@@ -109,7 +109,7 @@ constexpr static inline void generateCastlingMovesWhite(ValidMoves& validMoves, 
     if (board.castlingRights & CastleWhiteQueenSide) {
         // Pieces in the way - castling not allowed
         if (!(occupation & queenSideOccupationMask) && !(attacks & queenSideAttackMask)) {
-            validMoves.addMove(Move::createCastle(E1, C1, WhiteKing, CastleWhiteQueenSide));
+            validMoves.addMove(Move::createCastle(E1, C1, CastleWhiteQueenSide));
         }
     }
 
@@ -117,7 +117,7 @@ constexpr static inline void generateCastlingMovesWhite(ValidMoves& validMoves, 
     if (board.castlingRights & CastleWhiteKingSide) {
         // Pieces in the way - castling not allowed
         if (!(occupation & kingSideOccupationMask) && !(attacks & kingSideAttackMask)) {
-            validMoves.addMove(Move::createCastle(E1, G1, WhiteKing, CastleWhiteKingSide));
+            validMoves.addMove(Move::createCastle(E1, G1, CastleWhiteKingSide));
         }
     }
 }
@@ -135,7 +135,7 @@ constexpr static inline void generateCastlingMovesBlack(ValidMoves& validMoves, 
     if (board.castlingRights & CastleBlackQueenSide) {
         // Pieces in the way - castling not allowed
         if (!(occupation & queenSideOccupationMask) && !(attacks & queenSideAttackMask)) {
-            validMoves.addMove(Move::createCastle(E8, C8, BlackKing, CastleBlackQueenSide));
+            validMoves.addMove(Move::createCastle(E8, C8, CastleBlackQueenSide));
         }
     }
 
@@ -143,7 +143,7 @@ constexpr static inline void generateCastlingMovesBlack(ValidMoves& validMoves, 
     if (board.castlingRights & CastleBlackKingSide) {
         // Pieces in the way - castling not allowed
         if (!(occupation & kingSideOccupationMask) && !(attacks & kingSideAttackMask)) {
-            validMoves.addMove(Move::createCastle(E8, G8, BlackKing, CastleBlackKingSide));
+            validMoves.addMove(Move::createCastle(E8, G8, CastleBlackKingSide));
         }
     }
 }
@@ -154,9 +154,9 @@ template<Player player, MoveType type>
 constexpr static inline void getKnightMoves(ValidMoves& validMoves, const BitBoard& board)
 {
     if constexpr (player == PlayerWhite) {
-        generateKnightMoves<type>(validMoves, board.pieces[WhiteKnight], board.occupation[White], board.occupation[Black], Piece::WhiteKnight);
+        generateKnightMoves<type>(validMoves, board.pieces[WhiteKnight], board.occupation[White], board.occupation[Black]);
     } else {
-        generateKnightMoves<type>(validMoves, board.pieces[BlackKnight], board.occupation[Black], board.occupation[White], Piece::BlackKnight);
+        generateKnightMoves<type>(validMoves, board.pieces[BlackKnight], board.occupation[Black], board.occupation[White]);
     }
 }
 
@@ -164,9 +164,9 @@ template<Player player, MoveType type>
 constexpr static inline void getRookMoves(ValidMoves& validMoves, const BitBoard& board)
 {
     if constexpr (player == PlayerWhite) {
-        generateRookMoves<type>(validMoves, board.pieces[WhiteRook], board.occupation[White], board.occupation[Black], Piece::WhiteRook);
+        generateRookMoves<type>(validMoves, board.pieces[WhiteRook], board.occupation[White], board.occupation[Black]);
     } else {
-        generateRookMoves<type>(validMoves, board.pieces[BlackRook], board.occupation[Black], board.occupation[White], Piece::BlackRook);
+        generateRookMoves<type>(validMoves, board.pieces[BlackRook], board.occupation[Black], board.occupation[White]);
     }
 }
 
@@ -174,9 +174,9 @@ template<Player player, MoveType type>
 constexpr static inline void getBishopMoves(ValidMoves& validMoves, const BitBoard& board)
 {
     if constexpr (player == PlayerWhite) {
-        generateBishopMoves<type>(validMoves, board.pieces[WhiteBishop], board.occupation[White], board.occupation[Black], Piece::WhiteBishop);
+        generateBishopMoves<type>(validMoves, board.pieces[WhiteBishop], board.occupation[White], board.occupation[Black]);
     } else {
-        generateBishopMoves<type>(validMoves, board.pieces[BlackBishop], board.occupation[Black], board.occupation[White], Piece::BlackBishop);
+        generateBishopMoves<type>(validMoves, board.pieces[BlackBishop], board.occupation[Black], board.occupation[White]);
     }
 }
 
@@ -184,9 +184,9 @@ template<Player player, MoveType type>
 constexpr static inline void getQueenMoves(ValidMoves& validMoves, const BitBoard& board)
 {
     if constexpr (player == PlayerWhite) {
-        generateQueenMoves<type>(validMoves, board.pieces[WhiteQueen], board.occupation[White], board.occupation[Black], Piece::WhiteQueen);
+        generateQueenMoves<type>(validMoves, board.pieces[WhiteQueen], board.occupation[White], board.occupation[Black]);
     } else {
-        generateQueenMoves<type>(validMoves, board.pieces[BlackQueen], board.occupation[Black], board.occupation[White], Piece::BlackQueen);
+        generateQueenMoves<type>(validMoves, board.pieces[BlackQueen], board.occupation[Black], board.occupation[White]);
     }
 }
 
@@ -194,9 +194,9 @@ template<Player player, MoveType type>
 constexpr static inline void getKingMoves(ValidMoves& validMoves, const BitBoard& board, uint64_t attacks)
 {
     if constexpr (player == PlayerWhite) {
-        generateKingMoves<type>(validMoves, board.pieces[WhiteKing], board.occupation[White], board.occupation[Black], Piece::WhiteKing, attacks);
+        generateKingMoves<type>(validMoves, board.pieces[WhiteKing], board.occupation[White], board.occupation[Black], attacks);
     } else {
-        generateKingMoves<type>(validMoves, board.pieces[BlackKing], board.occupation[Black], board.occupation[White], Piece::BlackKing, attacks);
+        generateKingMoves<type>(validMoves, board.pieces[BlackKing], board.occupation[Black], board.occupation[White], attacks);
     }
 }
 

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -222,19 +222,19 @@ inline bool generateSyzygyMoves(const BitBoard& board, movegen::ValidMoves& move
 
         switch (TB_GET_PROMOTES(res)) {
         case TB_PROMOTES_NONE:
-            moves.addMove(movegen::Move::create(*from, *to, *attacker, isCapture));
+            moves.addMove(movegen::Move::create(*from, *to, isCapture));
             break;
         case TB_PROMOTES_QUEEN:
-            moves.addMove(movegen::Move::createPromotion(*from, *to, *attacker, PromotionQueen, isCapture));
+            moves.addMove(movegen::Move::createPromotion(*from, *to, PromotionQueen, isCapture));
             break;
         case TB_PROMOTES_ROOK:
-            moves.addMove(movegen::Move::createPromotion(*from, *to, *attacker, PromotionRook, isCapture));
+            moves.addMove(movegen::Move::createPromotion(*from, *to, PromotionRook, isCapture));
             break;
         case TB_PROMOTES_BISHOP:
-            moves.addMove(movegen::Move::createPromotion(*from, *to, *attacker, PromotionBishop, isCapture));
+            moves.addMove(movegen::Move::createPromotion(*from, *to, PromotionBishop, isCapture));
             break;
         case TB_PROMOTES_KNIGHT:
-            moves.addMove(movegen::Move::createPromotion(*from, *to, *attacker, PromotionKnight, isCapture));
+            moves.addMove(movegen::Move::createPromotion(*from, *to, PromotionKnight, isCapture));
             break;
         }
     }

--- a/tests/src/test_history_moves.cpp
+++ b/tests/src/test_history_moves.cpp
@@ -21,7 +21,7 @@ TEST_CASE("HistoryMoves: Updating quiet moves", "[HistoryMoves]")
 
     setPieceAtSquare(board, BlackKnight, C3);
 
-    Move quietMove = Move::create(C3, D5, BlackKnight, false);
+    Move quietMove = Move::create(C3, D5, false);
     REQUIRE(historyMoves.get(BlackKnight, D5) == 0);
 
     historyMoves.update(board, quietMove, 5);
@@ -39,8 +39,8 @@ TEST_CASE("HistoryMoves: Ignoring capture moves", "[HistoryMoves]")
 
     setPieceAtSquare(board, BlackPawn, B2);
 
-    Move captureMove = Move::create(B2, C3, BlackPawn, true);
-    Move quietMove = Move::create(B2, B4, BlackPawn, false);
+    Move captureMove = Move::create(B2, C3, true);
+    Move quietMove = Move::create(B2, B4, false);
 
     // only quit moves should be updated
     historyMoves.update(board, captureMove, 4);
@@ -56,7 +56,7 @@ TEST_CASE("HistoryMoves: Handling missing piece cases", "[HistoryMoves]")
     BitBoard board;
     board.player = PlayerBlack;
 
-    Move quietMove = Move::create(E4, G5, BlackBishop, false);
+    Move quietMove = Move::create(E4, G5, false);
     historyMoves.update(board, quietMove, 6);
 
     // Since there is no piece at E4, the history score should remain 0
@@ -70,7 +70,7 @@ TEST_CASE("HistoryMoves: Reset functionality", "[HistoryMoves]")
     board.player = PlayerBlack;
 
     setPieceAtSquare(board, BlackQueen, D1);
-    Move quietMove = Move::create(D1, H5, BlackQueen, false);
+    Move quietMove = Move::create(D1, H5, false);
 
     historyMoves.update(board, quietMove, 7);
     REQUIRE(historyMoves.get(BlackQueen, H5) == 7);

--- a/tests/src/test_killer_moves.cpp
+++ b/tests/src/test_killer_moves.cpp
@@ -12,8 +12,8 @@ TEST_CASE("KillerMoves: Updating with quiet moves", "[KillerMoves]")
 {
     KillerMoves killerMoves;
 
-    Move quietMove1 = Move::create(12, 28, WhiteKnight, false);
-    Move quietMove2 = Move::create(20, 36, WhiteBishop, false);
+    Move quietMove1 = Move::create(12, 28, false);
+    Move quietMove2 = Move::create(20, 36, false);
 
     REQUIRE(killerMoves.get(g_testPly) == KillerMoves::KillerMove {});
 
@@ -28,8 +28,8 @@ TEST_CASE("KillerMoves: Ignoring capture moves", "[KillerMoves]")
 {
     KillerMoves killerMoves;
 
-    Move captureMove = Move::create(10, 26, WhitePawn, true);
-    Move quietMove = Move::create(14, 30, WhiteQueen, false);
+    Move captureMove = Move::create(10, 26, true);
+    Move quietMove = Move::create(14, 30, false);
 
     killerMoves.update(captureMove, g_testPly);
     REQUIRE(killerMoves.get(g_testPly) == KillerMoves::KillerMove {});
@@ -45,8 +45,8 @@ TEST_CASE("KillerMoves: Reset functionality", "[KillerMoves]")
 {
     KillerMoves killerMoves;
 
-    Move quietMove1 = Move::create(8, 24, WhiteRook, false);
-    Move quietMove2 = Move::create(16, 32, WhiteKnight, false);
+    Move quietMove1 = Move::create(8, 24, false);
+    Move quietMove2 = Move::create(16, 32, false);
 
     killerMoves.update(quietMove1, g_testPly);
     killerMoves.update(quietMove2, g_testPly);

--- a/tests/src/test_move_vote_map.cpp
+++ b/tests/src/test_move_vote_map.cpp
@@ -13,7 +13,7 @@ TEST_CASE("MoveVoteMap", "[move_vote_map]")
 
     SECTION("Insert new move")
     {
-        Move m1(0x12345678);
+        const auto m1 = movegen::Move::create(A1, A2, false);
         voteMap.insertOrIncrement(m1, 1);
 
         REQUIRE(std::distance(voteMap.begin(), voteMap.end()) == 1);
@@ -23,7 +23,7 @@ TEST_CASE("MoveVoteMap", "[move_vote_map]")
 
     SECTION("Increment existing vote")
     {
-        Move m1(0x12345678);
+        const auto m1 = movegen::Move::create(A1, G2, false);
         voteMap.insertOrIncrement(m1, 2);
         voteMap.insertOrIncrement(m1, 3);
 
@@ -34,9 +34,9 @@ TEST_CASE("MoveVoteMap", "[move_vote_map]")
 
     SECTION("Insert multiple unique moves")
     {
-        Move m1(0x1);
-        Move m2(0x2);
-        Move m3(0x3);
+        const auto m1 = movegen::Move::create(A1, G2, false);
+        const auto m2 = movegen::Move::create(A2, G2, false);
+        const auto m3 = movegen::Move::create(A3, G2, false);
 
         voteMap.insertOrIncrement(m1, 1);
         voteMap.insertOrIncrement(m2, 2);
@@ -47,7 +47,7 @@ TEST_CASE("MoveVoteMap", "[move_vote_map]")
 
     SECTION("Clear resets entries")
     {
-        Move m1(0x12345678);
+        const auto m1 = movegen::Move::create(A1, G2, false);
         voteMap.insertOrIncrement(m1, 1);
 
         voteMap.clear();
@@ -57,7 +57,8 @@ TEST_CASE("MoveVoteMap", "[move_vote_map]")
 
     SECTION("Initializer list constructs map correctly")
     {
-        Move m1(0x10), m2(0x20);
+        const auto m1 = movegen::Move::create(A1, G2, false);
+        const auto m2 = movegen::Move::create(A2, G2, false);
         MoveVoteMap<maxSize> initMap { { m1, 2 }, { m2, 4 } };
 
         REQUIRE(std::distance(initMap.begin(), initMap.end()) == 2);

--- a/tests/src/test_pv_table.cpp
+++ b/tests/src/test_pv_table.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Test PVTable heuristic", "[PVTable]")
 
     SECTION("PVTable: Best move retrieval", "[PVTable]")
     {
-        Move move = Move::create(E2, E4, WhitePawn, false);
+        Move move = Move::create(E2, E4, false);
 
         pvTable.updateTable(move, 0);
 
@@ -36,20 +36,20 @@ TEST_CASE("Test PVTable heuristic", "[PVTable]")
         // This makes sense as we don't add any PV nodes UNTILL we've searched as deep as we need,
         // and THEN we will start adding moves
         for (int8_t p = G3; p >= A1; p--) {
-            Move move = Move::create(p, p + 8, WhitePawn, false);
+            Move move = Move::create(p, p + 8, false);
             pvTable.updateTable(move, p);
         }
 
         REQUIRE(pvTable.size() == size);
         for (uint8_t p = A1; p <= G3; p++) {
-            Move move = Move::create(p, p + 8, WhitePawn, false);
+            Move move = Move::create(p, p + 8, false);
             REQUIRE(pvTable[p] == move);
         }
     }
 
     SECTION("PVTable: Checking PV move status", "[PVTable]")
     {
-        Move move = Move::create(B1, C3, WhiteKnight, false);
+        Move move = Move::create(B1, C3, false);
 
         pvTable.updateTable(move, 0);
 
@@ -58,7 +58,7 @@ TEST_CASE("Test PVTable heuristic", "[PVTable]")
 
     SECTION("PVTable: Reset functionality", "[PVTable]")
     {
-        Move move = Move::create(E7, E5, WhitePawn, false);
+        Move move = Move::create(E7, E5, false);
 
         pvTable.updateTable(move, 0);
         REQUIRE(pvTable.bestMove() == move);
@@ -81,7 +81,7 @@ TEST_CASE("Test PVTable heuristic", "[PVTable]")
 
     SECTION("PVTable: Updating PV scoring", "[PVTable]")
     {
-        Move move = Move::create(H2, H4, WhitePawn, false);
+        Move move = Move::create(H2, H4, false);
         ValidMoves validMoves;
 
         validMoves.addMove(move);

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -6,6 +6,11 @@
 #define private public
 #include "evaluation/evaluator.h"
 
+constexpr auto getPiece(const BitBoard& board, movegen::Move move)
+{
+    return board.getAttackerAtSquare(move.fromSquare(), board.player);
+}
+
 TEST_CASE("Scoring", "[scoring]")
 {
     engine::TtHashTable::setSizeMb(16);
@@ -51,12 +56,12 @@ TEST_CASE("Scoring", "[scoring]")
             s_evaluator.m_searchers.at(0)->m_moveOrdering.sortMoves(board.value(), moves, 0);
 
             REQUIRE(moves.count() == 3);
-            REQUIRE(moves[0].piece() == WhitePawn);
-            REQUIRE(moves[1].piece() == WhiteKing);
-            REQUIRE(moves[2].piece() == WhiteRook);
+            REQUIRE(getPiece(*board, moves[0]) == WhitePawn);
+            REQUIRE(getPiece(*board, moves[1]) == WhiteKing);
+            REQUIRE(getPiece(*board, moves[2]) == WhiteRook);
 
             const auto move = s_evaluator.getBestMove(board.value(), 4);
-            REQUIRE(move.piece() == WhitePawn);
+            REQUIRE(getPiece(*board, move) == WhitePawn);
         }
 
         SECTION("Test capture and evasion moves")
@@ -68,12 +73,12 @@ TEST_CASE("Scoring", "[scoring]")
             engine::getAllMoves<movegen::MovePseudoLegal>(*board, moves);
             s_evaluator.m_searchers.at(0)->m_moveOrdering.sortMoves(board.value(), moves, 0);
 
-            REQUIRE(moves[0].piece() == WhitePawn);
-            REQUIRE(moves[1].piece() == WhiteKing);
-            REQUIRE(moves[2].piece() == WhiteRook);
+            REQUIRE(getPiece(*board, moves[0]) == WhitePawn);
+            REQUIRE(getPiece(*board, moves[1]) == WhiteKing);
+            REQUIRE(getPiece(*board, moves[2]) == WhiteRook);
 
             const auto move = s_evaluator.getBestMove(board.value(), 4);
-            REQUIRE(move.piece() == WhiteQueen); // evading attack + checking king = better move!
+            REQUIRE(getPiece(*board, move) == WhiteQueen); // evading attack + checking king = better move!
         }
     }
 }

--- a/tests/src/test_see_swap.cpp
+++ b/tests/src/test_see_swap.cpp
@@ -2,10 +2,15 @@
 #include "parsing/fen_parser.h"
 #include <catch2/catch_test_macros.hpp>
 
-std::optional<movegen::Move> findMoveToTarget(const movegen::ValidMoves& moves, Piece piece, BoardPosition target)
+constexpr auto getPiece(const BitBoard& board, movegen::Move move)
+{
+    return board.getAttackerAtSquare(move.fromSquare(), board.player);
+}
+
+std::optional<movegen::Move> findMoveToTarget(const BitBoard& board, const movegen::ValidMoves& moves, Piece piece, BoardPosition target)
 {
     for (const auto move : moves) {
-        if (move.piece() == piece && move.toPos() == target)
+        if (getPiece(board, move) == piece && move.toPos() == target)
             return move;
     }
 
@@ -37,10 +42,10 @@ TEST_CASE("Test See Swap", "[SeeSwap]")
 
         movegen::ValidMoves moves;
         engine::getAllMoves<movegen::MoveCapture>(*board, moves);
-        const auto move = findMoveToTarget(moves, WhiteKnight, E5);
+        const auto move = findMoveToTarget(*board, moves, WhiteKnight, E5);
 
         REQUIRE(move.has_value());
-        REQUIRE(move->piece() == WhiteKnight);
+        REQUIRE(getPiece(*board, *move) == WhiteKnight);
         REQUIRE(move->toPos() == E5);
 
         Score score = evaluation::SeeSwap::run(*board, *move);

--- a/tests/src/test_tt_hash_table.cpp
+++ b/tests/src/test_tt_hash_table.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Transposition Table - Basic Write & Read", "[TT]")
     uint64_t key = 0x123456789ABCDEF;
     Score score = 42;
 
-    const auto move = movegen::Move::create(A2, A4, WhitePawn, false);
+    const auto move = movegen::Move::create(A2, A4, false);
 
     TtHashTable::writeEntry(key, score, move, depth, ply, TtHashExact);
     auto retrieved = TtHashTable::TtHashTable::probe(key, depth, ply);
@@ -35,7 +35,7 @@ TEST_CASE("Transposition Table - Edge Case for Positive Score", "[TT]")
     uint64_t key = 0x123456789ABCDEF;
     Score score = s_maxScore;
 
-    const auto move = movegen::Move::create(A2, A4, WhitePawn, false);
+    const auto move = movegen::Move::create(A2, A4, false);
 
     TtHashTable::writeEntry(key, score, move, depth, ply, TtHashExact);
     auto retrieved = TtHashTable::TtHashTable::probe(key, depth, ply);
@@ -53,7 +53,7 @@ TEST_CASE("Transposition Table - Edge Case for Negative Score", "[TT]")
     uint64_t key = 0x123456789ABCDEF;
     Score score = s_minScore;
 
-    const auto move = movegen::Move::create(A2, A4, WhitePawn, false);
+    const auto move = movegen::Move::create(A2, A4, false);
 
     TtHashTable::writeEntry(key, score, move, depth, ply, TtHashExact);
     auto retrieved = TtHashTable::TtHashTable::probe(key, depth, ply);
@@ -72,8 +72,8 @@ TEST_CASE("Transposition Table - Depth Overwrite Rule", "[TT]")
     Score oldScore = 10;
     Score newScore = 50;
 
-    const auto move1 = movegen::Move::create(A2, A4, WhitePawn, false);
-    const auto move2 = movegen::Move::create(D7, D7, BlackPawn, false);
+    const auto move1 = movegen::Move::create(A2, A4, false);
+    const auto move2 = movegen::Move::create(D7, D7, false);
 
     TtHashTable::writeEntry(key, oldScore, move1, 3, ply, TtHashExact);
     TtHashTable::writeEntry(key, newScore, move2, 6, ply, TtHashExact); // Deeper depth
@@ -92,8 +92,8 @@ TEST_CASE("Transposition Table - Collision Handling", "[TT]")
     uint64_t key1 = 0x1111111111111111;
     uint64_t key2 = key1 + TtHashTable::s_ttHashSize; // Forces collision
 
-    const auto move1 = movegen::Move::create(A2, A4, WhitePawn, false);
-    const auto move2 = movegen::Move::create(D7, D7, BlackPawn, false);
+    const auto move1 = movegen::Move::create(A2, A4, false);
+    const auto move2 = movegen::Move::create(D7, D7, false);
 
     TtHashTable::writeEntry(key1, 30, move1, depth, ply, TtHashExact);
     TtHashTable::writeEntry(key2, 99, move2, depth, ply, TtHashExact);
@@ -117,7 +117,7 @@ TEST_CASE("Transposition Table - Score Clamping for Mating Scores", "[TT]")
 
     uint64_t key = 0xCAFEBABEDEADBEEF;
 
-    const auto move = movegen::Move::create(A2, A4, WhitePawn, false);
+    const auto move = movegen::Move::create(A2, A4, false);
     TtHashTable::writeEntry(key, nearMate, move, depth, ply, TtHashExact);
 
     SECTION("From same ply")
@@ -159,7 +159,7 @@ TEST_CASE("Transposition Table - Clear Functionality", "[TT]")
     engine::TtHashTable::setSizeMb(16);
 
     uint64_t key = 0xF00DBABE12345678;
-    const auto move = movegen::Move::create(A2, A4, WhitePawn, false);
+    const auto move = movegen::Move::create(A2, A4, false);
     TtHashTable::writeEntry(key, 77, move, depth, ply, TtHashExact);
 
     TtHashTable::clear();


### PR DESCRIPTION
We used to store quite a bit of metadata in the moves. For this to work we had to allocate 32bits for each move.
If we move the "piece" meta data to a look-up we can instead half the memory and store almost the same information.
This is beneficial for TT as we'll create 16bits of data that we can use for something else (todo).

Bench 12149207

[Test](https://openbench.bunny.beer/test/106/) is running