### PR TITLE
docker: Add clang to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM archlinux:latest
 # Install necessary packages
 RUN pacman -Sy --noconfirm \
     base-devel \
+    clang \
     gcc \
     mingw-w64-gcc \
     meson \


### PR DESCRIPTION
Tuner requires clang-format, which previously needed to be installed manually. Not any more...

Bench 8880290