### PR TITLE
searcher: add internal iterative reductions

### DIFF
--- a/src/evaluation/searcher.h
+++ b/src/evaluation/searcher.h
@@ -269,6 +269,13 @@ public:
             }
         }
 
+        /* Internal Iterative Reduction
+         * https://www.chessprogramming.org/Internal_Iterative_Reductions
+         * FIXME: replace check with ttMove when entries can contain static evals as well */
+        if (!hashProbe.has_value() && !isRoot && depth >= s_iirDepthLimit) {
+            depth -= s_iirReduction;
+        }
+
         /* https://www.chessprogramming.org/Razoring (Strelka) */
         if (!isPv && !isChecked && depth <= s_reductionLimit) {
             Score score = m_stackItr->eval + s_razorMarginShallow;
@@ -557,6 +564,8 @@ private:
     constexpr static inline Score s_razorMarginShallow { 125 };
     constexpr static inline Score s_razorMarginDeep { 175 };
     constexpr static inline uint8_t s_razorDeepReductionLimit { 2 };
+    constexpr static inline uint8_t s_iirDepthLimit { 4 };
+    constexpr static inline uint8_t s_iirReduction { 1 };
 
     constexpr static inline uint8_t s_nullMoveReduction { 2 };
 };


### PR DESCRIPTION
Internal Iterative Reductions (IIR) is a newer and more commonly used variant of Internal Iterative Deepening (IID).

The idea is that when no hash move is found, the guess is that the node must not be very important (at the current iteration).

Instead search one shallower depth and let the next iteration handle the deeper level (if found more important at this point).

Bench 8385565

[Test](https://openbench.bunny.beer/test/130/) is running