### PR TITLE
searcher: mute compilation warning

### DIFF
--- a/src/evaluation/searcher.h
+++ b/src/evaluation/searcher.h
@@ -79,7 +79,7 @@ public:
         m_wdl = syzygy::WdlResultTableNotActive;
         m_dtz = 0;
 
-        threadPool.submit([this, depth, board, alpha, beta] {
+        const bool started = threadPool.submit([this, depth, board, alpha, beta] {
             SearcherResult result {
                 .score
                 = negamax(depth, board, alpha, beta),
@@ -93,6 +93,8 @@ public:
 
             m_searchPromise.set_value(result);
         });
+
+        assert(started);
     }
 
     constexpr std::optional<SearcherResult> getSearchResult()


### PR DESCRIPTION
This warning has been present for some time now.
Add a debug flag to make it easier to track if it breaks at one point.

Bench 8880290