### PR TITLE
tt: add evaluation to entries

### DIFF
--- a/src/evaluation/score.h
+++ b/src/evaluation/score.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 using Score = int16_t;
 
 constexpr static inline Score s_maxScore = { 30000 };
 constexpr static inline Score s_minScore = { -s_maxScore };
+constexpr static inline Score s_noScore = std::numeric_limits<Score>::min();
 
 constexpr static inline Score s_mateValue { 20000 };
 constexpr static inline Score s_mateScore { s_mateValue - 1000 };
@@ -13,7 +15,9 @@ constexpr static inline Score s_mateScore { s_mateValue - 1000 };
 /* returns a score adjusted relative to ply (mate sooner = better) */
 constexpr inline int16_t scoreRelative(int16_t score, uint8_t ply)
 {
-    if (score > s_mateScore) {
+    if (score == s_noScore) {
+        return s_noScore;
+    } else if (score > s_mateScore) {
         score -= ply;
     } else if (score < -s_mateScore) {
         score += ply;
@@ -25,8 +29,9 @@ constexpr inline int16_t scoreRelative(int16_t score, uint8_t ply)
 /* Returns a score adjusted absolute, removing any ply shift */
 constexpr inline int16_t scoreAbsolute(int16_t score, uint8_t ply)
 {
-
-    if (score > s_mateScore) {
+    if (score == s_noScore) {
+        return s_noScore;
+    } else if (score > s_mateScore) {
         score += ply;
     } else if (score < -s_mateScore) {
         score -= ply;

--- a/src/movegen/move_types.h
+++ b/src/movegen/move_types.h
@@ -240,6 +240,9 @@ private:
     uint16_t data = 0;
 };
 
+/* helper to create explicit null moves */
+constexpr Move nullMove() { return Move(); }
+
 class ValidMoves {
 public:
     uint32_t count() const


### PR DESCRIPTION
As our static evaluation grows in complexity it also grows in time to
compute. Therefore it might be beneficial to add the evaluation to our
last slot in the transpostion table.

This commit adds the possibility to add a lighter entry in our tables.
It will contain no score nor move. Therefore I've also added a term
"noScore" and created a helper to create null moves.

As these "entries" are solely used for evaluation we ofc allow a full
search to be stored over a simple evaluation.

Bench 8688357

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>

Should be merged after #91 

Closes #89 

```
Elo   | 12.82 +- 9.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=128MB
LLR   | 3.14 (-2.94, 2.94) [0.00, 20.00]
Games | N: 2766 W: 942 L: 840 D: 984
Penta | [115, 271, 527, 337, 133]
https://openbench.bunny.beer/test/143/
```