### PR TITLE
searcher: depth based NMP | zugzwang check for NMP

### DIFF
--- a/src/bit_board.h
+++ b/src/bit_board.h
@@ -110,6 +110,17 @@ struct BitBoard {
         return (attacks[PlayerWhite] & occupation[PlayerBlack]) == 0 && (attacks[PlayerBlack] & occupation[PlayerWhite]) == 0;
     }
 
+    /* this is a very primitive way of checking for zugzwang position
+     * zugzwang is _very rare_ to happen outside of these conditions
+     * so for most cases this should be _super good enough_ */
+    constexpr inline bool hasZugzwangProneMaterial() const
+    {
+        if (player == PlayerWhite)
+            return occupation[PlayerWhite] == (pieces[WhitePawn] | pieces[WhiteKing]);
+        else
+            return occupation[PlayerBlack] == (pieces[BlackPawn] | pieces[BlackKing]);
+    }
+
     std::array<uint64_t, magic_enum::enum_count<Piece>()> pieces {};
     std::array<uint64_t, magic_enum::enum_count<Occupation>()> occupation {};
     std::array<uint64_t, magic_enum::enum_count<Player>()> attacks {};

--- a/src/evaluation/searcher.h
+++ b/src/evaluation/searcher.h
@@ -260,7 +260,7 @@ public:
 
         /* dangerous to repeat null search on a null search - skip it here */
         if constexpr (searchType != SearchType::NullSearch) {
-            if (depth > spsa::nullMoveReduction && !isChecked && m_ply) {
+            if (depth > spsa::nullMoveReduction && !isChecked && m_ply && !board.hasZugzwangProneMaterial()) {
                 if (const auto nullMoveScore = nullMovePruning(board, depth, beta)) {
                     return nullMoveScore.value();
                 }

--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -31,7 +31,10 @@
     TUNABLE(razorMarginShallow, Score, 125, 0, 250, 10)    \
     TUNABLE(razorMarginDeep, Score, 175, 0, 250, 10)       \
     TUNABLE(razorDeepReductionLimit, uint8_t, 2, 0, 12, 1) \
-    TUNABLE(nullMoveReduction, uint8_t, 2, 0, 12, 1)       \
+    TUNABLE(nmpBaseMargin, int8_t, -120, -200, 0, 10)      \
+    TUNABLE(nmpMarginFactor, uint8_t, 20, 0, 100, 5)       \
+    TUNABLE(nmpReductionBase, uint8_t, 4, 0, 12, 1)        \
+    TUNABLE(nmpReductionFactor, uint8_t, 4, 0, 12, 1)      \
     TUNABLE(aspirationWindow, uint8_t, 50, 10, 100, 5)     \
     TUNABLE(timeManMovesToGo, uint8_t, 20, 10, 40, 2)      \
     TUNABLE(timeManHardLimit, uint8_t, 3, 1, 5, 1)         \


### PR DESCRIPTION
Previously we would reduce depth with a fixed value when doing null
move pruning. We'd also use a naive depth check.

Instead replace the depth check with an evaluation margin check and
prune based on our current depth.

This allows us to do more fancy tricks in the future as well (improving
heuristics eg.)

Bench 7935208

```
zugswang only:
Elo   | 8.86 +- 6.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3882 W: 1261 L: 1162 D: 1459
Penta | [55, 314, 1125, 371, 76]
https://openbench.bunny.beer/test/199/

combined:
Elo   | 24.81 +- 11.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2160 W: 727 L: 573 D: 860
Penta | [82, 223, 358, 293, 124]
https://openbench.bunny.beer/test/200/
```