### PR TITLE
workflows: fix authors for releases

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          clean: true
+          fetch-depth: 0
       - name: Safe directory
         run: git config --global --add safe.directory '*'
       - name: Set version


### PR DESCRIPTION
Previously the checkout action would do a magic single depth checkout. This meant that all author contributions would be limited to that single commit assigned to the one triggering the action itself.

NOTE: `clean=true` is default, so I removed it

Bench 4397450