### PR TITLE
move_ordering: centralize scoring/following

### DIFF
--- a/src/evaluation/move_ordering.h
+++ b/src/evaluation/move_ordering.h
@@ -70,7 +70,6 @@ public:
             }
             moves[j] = key;
         }
-        m_pvTable.setIsScoring(false);
     }
 
     // Helper: calling inside loops will mean redundant colour checks
@@ -94,7 +93,7 @@ public:
             return ScoreTtHashMove;
         }
 
-        if (m_pvTable.isScoring() && m_pvTable.isPvMove(move, ply)) {
+        if (m_pvTable.isFollowing() && m_pvTable.isPvMove(move, ply)) {
             return ScorePvLine;
         }
 

--- a/src/evaluation/pv_table.h
+++ b/src/evaluation/pv_table.h
@@ -26,7 +26,6 @@ public:
         std::ranges::fill(m_pvLength, 0);
 
         m_isFollowing = false;
-        m_isScoring = false;
     }
 
     movegen::Move bestMove() const
@@ -60,19 +59,9 @@ public:
         m_isFollowing = val;
     }
 
-    void setIsScoring(bool val)
-    {
-        m_isScoring = val;
-    }
-
     bool isFollowing() const
     {
         return m_isFollowing;
-    }
-
-    bool isScoring() const
-    {
-        return m_isScoring;
     }
 
     bool isPvMove(movegen::Move move, uint8_t ply) const
@@ -86,7 +75,6 @@ public:
 
         for (const auto& move : moves) {
             if (isPvMove(move, ply)) {
-                m_isScoring = true;
                 m_isFollowing = true;
             }
         }
@@ -119,8 +107,6 @@ private:
     std::array<PVNode, s_pvTableSize> m_pvTable {};
     std::array<uint8_t, s_pvTableSize> m_pvLength {};
 
-    /* TODO: use single state instead of two bools - will be racy when we start multi threading */
-    bool m_isScoring;
     bool m_isFollowing;
 };
 }

--- a/tests/src/test_pv_table.cpp
+++ b/tests/src/test_pv_table.cpp
@@ -72,24 +72,7 @@ TEST_CASE("Test PVTable heuristic", "[PVTable]")
         pvTable.setIsFollowing(true);
         REQUIRE(pvTable.isFollowing() == true);
 
-        pvTable.setIsScoring(true);
-        REQUIRE(pvTable.isScoring() == true);
-
         pvTable.setIsFollowing(false);
         REQUIRE(pvTable.isFollowing() == false);
     }
-
-    SECTION("PVTable: Updating PV scoring", "[PVTable]")
-    {
-        Move move = Move::create(H2, H4, false);
-        ValidMoves validMoves;
-
-        validMoves.addMove(move);
-        pvTable.updateTable(move, 0);
-
-        REQUIRE(pvTable.isScoring() == false);
-        pvTable.updatePvScoring(validMoves, 0);
-        REQUIRE(pvTable.isScoring() == true);
-    }
 }
-


### PR DESCRIPTION
This flag was redundant, because it was guaranteed to always equal `m_isFollowing` at the time of move sorting.

Bench 4297313

https://openbench.bunny.beer/test/207/