### PR TITLE
uci-options: fix spsa bugs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,5 +92,5 @@ jobs:
     - name: Safe directory
       run: git config --global --add safe.directory '*'
     - name: Build with SPSA enabled
-      run: tuner/scripts/build.sh --spsa
+      run: scripts/build.sh --spsa
 

--- a/src/parsing/input_parsing.h
+++ b/src/parsing/input_parsing.h
@@ -9,9 +9,9 @@
 
 namespace parsing {
 
-std::optional<uint64_t> to_number(std::string_view str)
+inline std::optional<int64_t> to_number(std::string_view str)
 {
-    int result {};
+    int64_t result {};
     auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
 
     // Check for conversion errors or extra characters

--- a/src/uci_options.h
+++ b/src/uci_options.h
@@ -15,7 +15,7 @@ namespace ucioption {
 /* uci types for easier creation */
 using string = std::string;
 using check = bool;
-using spin = uint64_t;
+using spin = int64_t;
 
 template<typename T>
 struct Storage {
@@ -27,11 +27,11 @@ struct Storage {
 using Variant = std::variant<
     Storage<std::string>,
     Storage<bool>,
-    Storage<uint64_t>>;
+    Storage<int64_t>>;
 
 struct Limits {
-    uint64_t min;
-    uint64_t max;
+    int64_t min;
+    int64_t max;
 };
 
 struct UciOption {
@@ -73,7 +73,7 @@ constexpr bool handleInput(UciOption& option, std::string_view input)
             }
         } else if constexpr (std::is_same_v<T, Storage<std::string>>) {
             arg.value = input;
-        } else if constexpr (std::is_same_v<T, Storage<uint64_t>>) {
+        } else if constexpr (std::is_same_v<T, Storage<int64_t>>) {
             const auto inputNum = parsing::to_number(input);
             if (!inputNum.has_value())
                 return false;
@@ -121,7 +121,7 @@ constexpr std::string_view uciTypeToString(Variant variant)
             return "check";
         } else if constexpr (std::is_same_v<T, Storage<std::string>>) {
             return "string";
-        } else if constexpr (std::is_same_v<T, Storage<uint64_t>>) {
+        } else if constexpr (std::is_same_v<T, Storage<int64_t>>) {
             return "spin";
         } else {
             static_assert(false, "string conversion has not yet been implemented");


### PR DESCRIPTION
1. spin value should be signed (allow negative values)
2. print debug options for spsa values as well
3. input parsing could only return unsigned values
4. the spsa uci options were not hooked up to the uci handler
5. pull request workflow was using the wrong build script

Bench 4297319