### PR TITLE
searcher: improve when stopped | fix syzygy threading bug | fix shutdown memory issue

### DIFF
--- a/src/core/time_manager.h
+++ b/src/core/time_manager.h
@@ -57,7 +57,7 @@ public:
     {
         const Duration timeSpent = std::chrono::steady_clock::now() - s_startTime;
         if (timeSpent >= s_hardTimeLimit) {
-            s_timedOut = true;
+            s_timedOut.store(true, std::memory_order_relaxed);
         }
     }
 

--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -241,6 +241,11 @@ private:
                 Searcher::setSearchStopped(false);
                 const auto score = singleSearcher->startSearch(d, board, alpha, beta);
 
+                /* use previous search if we timed out - it means that the current search was incomplete */
+                if (TimeManager::hasTimedOut()) {
+                    break;
+                }
+
                 if ((score <= alpha) || (score >= beta)) {
                     alpha = s_minScore;
                     beta = s_maxScore;
@@ -278,6 +283,11 @@ private:
                             ++numSearchResults;
                         }
                     }
+                }
+
+                /* use previous search if we timed out - it means that the current search was incomplete */
+                if (TimeManager::hasTimedOut()) {
+                    break;
                 }
 
                 if (numSearchResults == 0) {

--- a/src/evaluation/evaluator.h
+++ b/src/evaluation/evaluator.h
@@ -37,6 +37,11 @@ public:
 
         m_searchers.resize(size);
         m_threadPool.resize(size + 2);
+
+        bool primarySearcher = true;
+        for (auto& searcher : m_searchers) {
+            searcher->setIsPrimary(std::exchange(primarySearcher, false));
+        }
     }
 
     constexpr uint64_t getNodes() const

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -310,9 +310,10 @@ public:
         bool tbMoves = false;
         movegen::ValidMoves moves {};
         if (syzygy::isTableActive(board)) {
-            if (isRoot) {
+            /* generateSyzygyMoves is not thread safe - allow primary searcher only to take this path! */
+            if (isRoot && m_isPrimary) {
                 tbMoves = syzygy::generateSyzygyMoves(board, moves, m_wdl, m_dtz);
-            } else if (board.isQuietPosition()) {
+            } else if (!isRoot && board.isQuietPosition()) {
                 Score score = 0;
                 syzygy::probeWdl(board, score);
                 core::TranspositionTable::writeEntry(m_stackItr->hash, score, m_stackItr->eval, movegen::Move {}, s_maxSearchDepth, m_ply, core::TtExact);

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -101,8 +101,7 @@ public:
 
         const bool started = threadPool.submit([this, depth, board, alpha, beta] {
             SearcherResult result {
-                .score
-                = negamax(depth, board, alpha, beta),
+                .score = negamax(depth, board, alpha, beta),
                 .pvMove = m_movePicker.pvTable().bestMove(),
                 .searchedDepth = m_movePicker.pvTable().size(),
                 .searcher = this
@@ -388,7 +387,7 @@ public:
             undoMove();
 
             if (isSearchStopped())
-                return score;
+                return s_minScore;
 
             if (score >= beta) {
                 core::TranspositionTable::writeEntry(m_stackItr->hash, score, m_stackItr->eval, move, depth, m_ply, core::TtBeta);
@@ -476,7 +475,7 @@ private:
             undoMove();
 
             if (isSearchStopped())
-                return score;
+                return s_minScore;
 
             if (score >= beta)
                 return beta;

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -47,6 +47,11 @@ public:
         m_stack.front().hash = hash;
     }
 
+    void setIsPrimary(bool isPrimary)
+    {
+        m_isPrimary = isPrimary;
+    }
+
     constexpr uint64_t getNodes() const
     {
         return m_nodes;
@@ -586,7 +591,7 @@ private:
         if (s_searchStopped.load(std::memory_order_relaxed))
             return true;
 
-        if (m_nodes % 2048 == 0) {
+        if (m_isPrimary && m_nodes % 2048 == 0) {
             TimeManager::updateTimeout();
         }
 
@@ -602,6 +607,7 @@ private:
     Repetition m_repetition;
     MovePicker m_movePicker {};
     uint8_t m_selDepth {};
+    bool m_isPrimary { true };
 
     syzygy::WdlResult m_wdl { syzygy::WdlResultTableNotActive };
     uint8_t m_dtz {};

--- a/src/syzygy/syzygy.h
+++ b/src/syzygy/syzygy.h
@@ -193,6 +193,8 @@ inline void printDtzDebug(const BitBoard& board)
     }
 }
 
+/* NOTE: this method is not thread safe (tb_probe_root is declared as non-thread safe)
+ * NOTE: this method should only be called once from root */
 inline bool generateSyzygyMoves(const BitBoard& board, movegen::ValidMoves& moves, WdlResult& wdl, uint8_t& dtz)
 {
     std::array<uint32_t, TB_MAX_MOVES> results;


### PR DESCRIPTION
See each commit :)

```
Syzygy disabled:
Elo   | 11.43 +- 11.31 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=128MB
LLR   | 1.38 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1764 W: 486 L: 428 D: 850
Penta | [42, 212, 335, 232, 61]
https://openbench.bunny.beer/test/288/
```

```
Syzygy enabled:
Elo   | 3.75 +- 7.11 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=128MB
LLR   | 1.05 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2688 W: 573 L: 544 D: 1571
Penta | [17, 300, 692, 307, 28]
https://openbench.bunny.beer/test/284/
```