### PR TITLE
searcher: add qsearch tt alpha move write

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -469,6 +469,11 @@ private:
             }
         }
 
+        /* entries for the TT hash */
+        core::TtFlag hashFlag = core::TtAlpha;
+        movegen::Move alphaMove = movegen::nullMove();
+        Score bestScore = m_stackItr->eval;
+
         movegen::ValidMoves moves;
         core::getAllMoves<movegen::MoveCapture>(board, moves);
         auto phase = PickerPhase::TtMove;
@@ -487,15 +492,24 @@ private:
             if (isSearchStopped())
                 return s_minScore;
 
-            if (score >= beta)
-                return beta;
+            if (score > bestScore) {
+                bestScore = score;
+            }
+
+            if (score >= beta) {
+                core::TranspositionTable::writeEntry(m_stackItr->hash, bestScore, m_stackItr->eval, move, 0, m_ply, core::TtBeta);
+                return bestScore;
+            }
 
             if (score > alpha) {
+                alphaMove = move;
+                hashFlag = core::TtExact;
                 alpha = score;
             }
         }
 
-        return alpha;
+        core::TranspositionTable::writeEntry(m_stackItr->hash, bestScore, m_stackItr->eval, alphaMove, 0, m_ply, hashFlag);
+        return bestScore;
     }
 
     /*


### PR DESCRIPTION
This commit adds handling similar to negamax (or actually the same
except no depth is provided):
When qsearch has completed, write the alpha move to transposition table.

Bench 3078472

```
Elo   | 30.54 +- 20.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 20.00]
Games | N: 536 W: 171 L: 124 D: 241
Penta | [10, 61, 87, 92, 18]
https://openbench.bunny.beer/test/282/
```