### PR TITLE
searcher: create SearchTable, clean up picker state

### DIFF
--- a/src/search/search_tables.h
+++ b/src/search/search_tables.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "search/history_moves.h"
+#include "search/killer_moves.h"
+#include "search/pv_table.h"
+
+namespace search {
+
+class SearchTables {
+public:
+    inline void reset()
+    {
+        m_killerMoves.reset();
+        m_historyMoves.reset();
+        m_pvTable.reset();
+    }
+
+    inline bool isPvScoring() const
+    {
+        return m_pvTable.isScoring();
+    }
+
+    inline bool isPvFollowing() const
+    {
+        return m_pvTable.isFollowing();
+    }
+
+    inline bool isPvMove(movegen::Move move, uint8_t ply) const
+    {
+        return m_pvTable.isPvMove(move, ply);
+    }
+
+    inline movegen::Move getBestPvMove() const
+    {
+        return m_pvTable.bestMove();
+    }
+
+    inline uint8_t getPvSize() const
+    {
+        return m_pvTable.size();
+    }
+    inline const PVTable& getPvTable() const
+    {
+        return m_pvTable;
+    }
+
+    inline movegen::Move getPonderMove() const
+    {
+        return m_pvTable.ponderMove();
+    }
+
+    inline void setPvIsFollowing(bool val)
+    {
+        m_pvTable.setIsFollowing(val);
+    }
+
+    inline void setPvIsScoring(bool val)
+    {
+        m_pvTable.setIsScoring(val);
+    }
+
+    inline void updatePvLength(uint8_t ply)
+    {
+        m_pvTable.updateLength(ply);
+    }
+
+    inline void updatePvTable(movegen::Move move, uint8_t ply)
+    {
+        m_pvTable.updateTable(move, ply);
+    }
+
+    inline void updatePvScoring(const movegen::ValidMoves& moves, uint8_t ply)
+    {
+        m_pvTable.updatePvScoring(moves, ply);
+    }
+
+    inline void resetHistoryNodes()
+    {
+        m_historyMoves.resetNodes();
+    }
+
+    inline std::pair<movegen::Move, movegen::Move> getKillerMove(uint8_t ply) const
+    {
+        return m_killerMoves.get(ply);
+    }
+
+    inline void updateKillerMoves(movegen::Move move, uint8_t ply)
+    {
+        m_killerMoves.update(move, ply);
+    }
+
+    inline int32_t getHistoryMove(Piece movePiece, uint8_t targetPosition) const
+    {
+        return m_historyMoves.get(movePiece, targetPosition);
+    }
+
+    inline void addHistoryNodes(movegen::Move move, uint64_t nodes)
+    {
+        m_historyMoves.addNodes(move, nodes);
+    }
+
+    inline uint64_t getHistoryNodes(movegen::Move move) const
+    {
+        return m_historyMoves.getNodes(move);
+    }
+
+    inline void updateHistoryMoves(const BitBoard& board, movegen::Move move, uint8_t ply)
+    {
+        m_historyMoves.update(board, move, ply);
+    }
+
+private:
+    PVTable m_pvTable {};
+
+    KillerMoves m_killerMoves {};
+    HistoryMoves m_historyMoves {};
+};
+};

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -56,10 +56,11 @@ TEST_CASE("Scoring", "[scoring]")
             movegen::ValidMoves moves;
             core::getAllMoves<movegen::MoveCapture>(*board, moves);
 
-            auto phase = PickerPhase::TtMove;
             movegen::ValidMoves results {};
+            SearchTables searchTables {};
+            MovePicker picker {};
 
-            while (const auto moveOpt = s_evaluator.m_searchers.at(0)->m_movePicker.pickNextMove(phase, *board, moves, 0)) {
+            while (const auto moveOpt = picker.pickNextMove(*board, searchTables, moves, 0)) {
                 results.addMove(moveOpt.value());
             }
 
@@ -83,10 +84,11 @@ TEST_CASE("Scoring", "[scoring]")
             movegen::ValidMoves moves;
             core::getAllMoves<movegen::MovePseudoLegal>(*board, moves);
 
-            auto phase = PickerPhase::TtMove;
             movegen::ValidMoves results {};
+            SearchTables searchTables {};
+            MovePicker picker {};
 
-            while (const auto moveOpt = s_evaluator.m_searchers.at(0)->m_movePicker.pickNextMove(phase, *board, moves, 0)) {
+            while (const auto moveOpt = picker.pickNextMove(*board, searchTables, moves, 0)) {
                 results.addMove(moveOpt.value());
             }
 


### PR DESCRIPTION
Lighter move picker can be duplicated easily, so this commit also introduces multiple pickers, each with their own state.

We no longer expose the PV table etc. Instead, the search table now acts as an API for PV table, history and killer moves.

Bench 3078472.

https://openbench.bunny.beer/test/300/