### PR TITLE
build: only allow cache for dev builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,11 @@ if [[ "$OPTIMIZATION" == "dev" ]]; then
     ARGS+=("-Ddeveloper-build=true")
 fi
 
+# only allow cached builds for dev builds
+if [[ "$OPTIMIZATION" == "release" ]]; then
+    rm -rf "$BUILD_DIR" || true
+fi
+
 # custom build for SPSA to ensure proper meson setup
 if $SPSA; then
     ARGS+=("-Dspsa=true")


### PR DESCRIPTION
Meson does not handle paths very well when eg. build from different context (container or local).

The simplest fix for this is to only allow cached builds for developers. Release builds should be clean by nature to ensure that we don't have potential pollution etc.

Bench 3255686