### PR TITLE
searcher: add cut node

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -226,7 +226,7 @@ public:
     }
 
     template<SearchType searchType = SearchType::Default>
-    constexpr Score negamax(uint8_t depth, const BitBoard& board, Score alpha = s_minScore, Score beta = s_maxScore)
+    constexpr Score negamax(uint8_t depth, const BitBoard& board, Score alpha = s_minScore, Score beta = s_maxScore, bool cutNode = false)
     {
         const bool isRoot = m_ply == 0;
 
@@ -296,7 +296,7 @@ public:
             if constexpr (searchType != SearchType::NullSearch) {
                 const Score nmpMargin = spsa::nmpBaseMargin + spsa::nmpMarginFactor * depth;
                 if (m_stackItr->eval + nmpMargin >= beta && !isRoot && !board.hasZugzwangProneMaterial()) {
-                    if (const auto nullMoveScore = nullMovePruning(board, depth, beta)) {
+                    if (const auto nullMoveScore = nullMovePruning(board, depth, beta, cutNode)) {
                         return nullMoveScore.value();
                     }
                 }
@@ -365,7 +365,7 @@ public:
 
             if (movesSearched == 0) {
                 /* no moves searched yet -> perform a full depth PV move search */
-                score = -negamax(depth - 1, m_stackItr->board, -beta, -alpha);
+                score = -negamax(depth - 1, m_stackItr->board, -beta, -alpha, !(isPv || cutNode));
             } else {
                 /* other moves we can attempt searched with a reduced zero window search
                  * if the zero window search increases alpha we increase the window size */
@@ -380,22 +380,24 @@ public:
                     reduction -= static_cast<int8_t>(isChecked); /* reduce less when checked */
                     reduction -= static_cast<int8_t>(isGivingCheck); /* reduce less when giving check */
                     reduction += static_cast<int8_t>(!isPv); /* reduce more when not pv line */
+                    reduction += static_cast<int8_t>(cutNode); /* reduce more when cut-node */
+
                     reduction = std::clamp<uint8_t>(reduction, 0, depth - 1);
                 }
 
                 /* first try zero window search with reduced depth (best case scenario) */
-                score = -zeroWindow(depth - 1 - reduction, m_stackItr->board, -alpha);
+                score = -zeroWindow(depth - 1 - reduction, m_stackItr->board, -alpha, true);
 
                 /* above failed high, so attempt a zero window search but with no reductions */
                 if (score > alpha && reduction > 0) {
-                    score = -zeroWindow(depth - 1, m_stackItr->board, -alpha);
+                    score = -zeroWindow(depth - 1, m_stackItr->board, -alpha, !cutNode);
                 }
 
                 /* if both reduced and non-reduced zero search failed high then we're forced
                  * to do a full depth full window search
                  * this search has PV potential, so the cost is worth it! */
                 if (score > alpha && score < beta) {
-                    score = -negamax(depth - 1, m_stackItr->board, -beta, -alpha);
+                    score = -negamax(depth - 1, m_stackItr->board, -beta, -alpha, !(isPv || cutNode));
                 }
             }
 
@@ -450,9 +452,9 @@ public:
 
 private:
     template<SearchType searchType = Default>
-    inline Score zeroWindow(uint8_t depth, const BitBoard& board, Score window)
+    inline Score zeroWindow(uint8_t depth, const BitBoard& board, Score window, bool cutNode)
     {
-        return negamax<searchType>(depth, board, window - 1, window);
+        return negamax<searchType>(depth, board, window - 1, window, cutNode);
     }
 
     constexpr Score quiesence(const BitBoard& board, Score alpha, Score beta)
@@ -535,7 +537,7 @@ private:
      * null move pruning
      * https://www.chessprogramming.org/Null_Move_Pruning
      * */
-    std::optional<Score> nullMovePruning(const BitBoard& board, uint8_t depth, Score beta)
+    std::optional<Score> nullMovePruning(const BitBoard& board, uint8_t depth, Score beta, bool cutNode)
     {
         auto nullMoveBoard = board;
         uint64_t hash = m_stackItr->hash;
@@ -562,7 +564,7 @@ private:
 
         /* perform search with reduced depth (based on reduction limit) */
         const uint8_t reduction = std::min<uint8_t>(depth, spsa::nmpReductionBase + depth / spsa::nmpReductionFactor);
-        Score score = -zeroWindow<SearchType::NullSearch>(depth - reduction, nullMoveBoard, -beta + 1);
+        Score score = -zeroWindow<SearchType::NullSearch>(depth - reduction, nullMoveBoard, -beta + 1, !cutNode);
 
         m_ply -= 2;
         m_stackItr -= 2;


### PR DESCRIPTION
More info about cut-nodes can be found here:
https://www.chessprogramming.org/Node_Types#Cut-Nodes

For now add it to lmr reduction as it's the simplest application.

Bench 3230833

```
Elo   | 2.73 +- 4.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.60 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11340 W: 3059 L: 2970 D: 5311
Penta | [373, 1386, 2093, 1415, 403]
https://openbench.bunny.beer/test/310/
```