### PR TITLE
searcher: add internal iterative reduction

### DIFF
--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -35,6 +35,7 @@
     TUNABLE(nmpMarginFactor, uint8_t, 20, 0, 100, 5)             \
     TUNABLE(nmpReductionBase, uint8_t, 4, 0, 12, 1)              \
     TUNABLE(nmpReductionFactor, uint8_t, 4, 0, 12, 1)            \
+    TUNABLE(iirDepthLimit, uint8_t, 4, 0, 12, 1)                 \
     TUNABLE(aspirationWindow, uint8_t, 50, 10, 100, 5)           \
     TUNABLE(timeManIncFrac, uint16_t, 75, 1, 150, 5)             \
     TUNABLE(timeManBaseFrac, uint16_t, 50, 1, 150, 5)            \


### PR DESCRIPTION
This commit adds 'internal iterative reduction' (IIR)

The assumtion is that if no tt move was found for a given node
then it most not be very important - instead reduce it for now and let
future deeper searches explore that node (if important)

Bench 2389574

```
Elo   | 17.38 +- 8.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3242 W: 956 L: 794 D: 1492
Penta | [88, 350, 613, 452, 118]
https://openbench.bunny.beer/test/312/
```