### PR TITLE
move_picker: move generation to picker

### DIFF
--- a/src/search/move_picker.h
+++ b/src/search/move_picker.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "core/bit_board.h"
+#include "core/move_handling.h"
 
 #include "evaluation/see_swap.h"
 #include "movegen/move_types.h"
 
 #include "search/search_tables.h"
+#include "syzygy/syzygy.h"
 
 #include <cstdint>
 
@@ -17,7 +19,9 @@ enum KillerMoveType {
 };
 
 enum PickerPhase {
+    GenerateSyzygyMoves,
     Syzygy,
+    GenerateMoves,
     TtMove,
     PvMove,
     CaptureGood,
@@ -31,123 +35,143 @@ enum PickerPhase {
     Done,
 };
 
+template<movegen::MoveType moveType>
 class MovePicker {
 public:
-    MovePicker(
-        SearchTables& searchTables, uint8_t ply, std::optional<movegen::Move> ttMove = std::nullopt, std::optional<movegen::Move> prevMove = std::nullopt, PickerPhase phase = PickerPhase::TtMove)
+    MovePicker(SearchTables& searchTables, uint8_t ply, PickerPhase phase, std::optional<movegen::Move> ttMove = std::nullopt, std::optional<movegen::Move> prevMove = std::nullopt)
         : m_searchTables(searchTables)
         , m_ply(ply)
+        , m_phase(phase)
         , m_ttMove(ttMove)
         , m_prevMove(prevMove)
-        , m_phase(phase)
     {
     }
 
-    void setPhase(PickerPhase phase)
+    constexpr uint16_t numGeneratedMoves()
     {
-        m_phase = phase;
+        return m_moves.count();
     }
 
-    template<Player player> constexpr std::optional<movegen::Move> pickNextMove(const BitBoard& board, movegen::ValidMoves& moves)
+    template<Player player> constexpr std::optional<movegen::Move> pickNextMove(const BitBoard& board)
     {
         switch (m_phase) {
+        case GenerateSyzygyMoves: {
+            const bool syzygyActive = syzygy::generateSyzygyMoves(board, m_moves);
+
+            if (syzygyActive) {
+                m_phase = PickerPhase::Syzygy;
+            } else {
+                m_phase = PickerPhase::GenerateMoves;
+            }
+
+            return pickNextMove<player>(board);
+        }
+
         case Syzygy: {
 
-            if (const auto pickedMove = pickSyzygyMove(moves))
+            if (const auto pickedMove = pickSyzygyMove())
                 return pickedMove;
 
             m_phase = PickerPhase::Done;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
+        }
+
+        case GenerateMoves: {
+            generateAllMoves(board);
+
+            m_phase = PickerPhase::TtMove;
+
+            return pickNextMove<player>(board);
         }
 
         case TtMove: {
-            if (const auto pickedMove = pickTtMove(moves))
+            if (const auto pickedMove = pickTtMove())
                 return pickedMove;
 
             m_phase = PickerPhase::PvMove;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case PvMove: {
-            if (const auto pickedMove = pickPvMove(moves))
+            if (const auto pickedMove = pickPvMove())
                 return pickedMove;
 
             m_phase = PickerPhase::CaptureGood;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case CaptureGood: {
-            if (const auto pickedMove = pickCapture<true>(board, moves))
+            if (const auto pickedMove = pickCapture<true>(board))
                 return pickedMove;
 
             m_phase = PickerPhase::PromotionGood;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case PromotionGood: {
-            if (const auto pickedMove = pickPromotion<true>(moves))
+            if (const auto pickedMove = pickPromotion<true>())
                 return pickedMove;
 
             m_phase = PickerPhase::KillerMoveFirst;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case KillerMoveFirst: {
-            if (const auto pickedMove = pickKillerMove(KillerMoveType::First, moves))
+            if (const auto pickedMove = pickKillerMove(KillerMoveType::First))
                 return pickedMove;
 
             m_phase = PickerPhase::KillerMoveSecond;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case KillerMoveSecond: {
-            if (const auto pickedMove = pickKillerMove(KillerMoveType::Second, moves))
+            if (const auto pickedMove = pickKillerMove(KillerMoveType::Second))
                 return pickedMove;
 
             m_phase = PickerPhase::CounterMove;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case CounterMove: {
-            if (const auto pickedMove = pickCounterMove(moves))
+            if (const auto pickedMove = pickCounterMove())
                 return pickedMove;
 
             m_phase = PickerPhase::HistoryMove;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case HistoryMove: {
-            if (const auto pickedMove = pickHistoryMove<player>(board, moves))
+            if (const auto pickedMove = pickHistoryMove<player>(board))
                 return pickedMove;
 
             m_phase = PickerPhase::PromotionBad;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case PromotionBad: {
-            if (const auto pickedMove = pickPromotion<false>(moves))
+            if (const auto pickedMove = pickPromotion<false>())
                 return pickedMove;
 
             m_phase = PickerPhase::BadCapture;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
         case BadCapture: {
-            if (const auto pickedMove = pickCapture<false>(board, moves))
+            if (const auto pickedMove = pickCapture<false>(board))
                 return pickedMove;
 
             m_phase = PickerPhase::Done;
 
-            return pickNextMove<player>(board, moves);
+            return pickNextMove<player>(board);
         }
 
         case Done:
@@ -158,24 +182,35 @@ public:
     }
 
     // Helper: calling inside loops will mean redundant colour checks
-    constexpr std::optional<movegen::Move> pickNextMove(const BitBoard& board, movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickNextMove(const BitBoard& board)
     {
         if (board.player == PlayerWhite) {
-            return pickNextMove<PlayerWhite>(board, moves);
+            return pickNextMove<PlayerWhite>(board);
         } else {
-            return pickNextMove<PlayerBlack>(board, moves);
+            return pickNextMove<PlayerBlack>(board);
         }
     }
 
 private:
-    // Syzygy moves are already sorted: return first, then second, third etc
-    constexpr std::optional<movegen::Move> pickSyzygyMove(movegen::ValidMoves& moves)
+    constexpr void generateAllMoves(const BitBoard& board)
     {
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull()) {
-                const auto pickedMove = moves[i];
+        core::getAllMoves<moveType>(board, m_moves);
 
-                moves.nullifyMove(i);
+        if constexpr (moveType == movegen::MovePseudoLegal) {
+            if (m_searchTables.isPvFollowing()) {
+                m_searchTables.updatePvScoring(m_moves, m_ply);
+            }
+        }
+    }
+
+    // Syzygy moves are already sorted: return first, then second, third etc
+    constexpr std::optional<movegen::Move> pickSyzygyMove()
+    {
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull()) {
+                const auto pickedMove = m_moves[i];
+
+                m_moves.nullifyMove(i);
 
                 return pickedMove;
             }
@@ -183,16 +218,16 @@ private:
         return std::nullopt;
     }
 
-    constexpr std::optional<movegen::Move> pickTtMove(movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickTtMove()
     {
         if (!m_ttMove.has_value())
             return std::nullopt;
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull() && moves[i] == *m_ttMove) {
-                const auto ttMove = moves[i];
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull() && m_moves[i] == *m_ttMove) {
+                const auto ttMove = m_moves[i];
 
-                moves.nullifyMove(i);
+                m_moves.nullifyMove(i);
 
                 return ttMove;
             }
@@ -200,16 +235,16 @@ private:
         return std::nullopt;
     }
 
-    constexpr std::optional<movegen::Move> pickPvMove(movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickPvMove()
     {
         if (!m_searchTables.isPvScoring())
             return std::nullopt;
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull() && m_searchTables.isPvMove(moves[i], m_ply)) {
-                const auto pickedMove = moves[i];
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull() && m_searchTables.isPvMove(m_moves[i], m_ply)) {
+                const auto pickedMove = m_moves[i];
 
-                moves.nullifyMove(i);
+                m_moves.nullifyMove(i);
 
                 m_searchTables.setPvIsScoring(false);
 
@@ -220,26 +255,26 @@ private:
     }
 
     template<bool isGood>
-    constexpr std::optional<movegen::Move> pickCapture(const BitBoard& board, movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickCapture(const BitBoard& board)
     {
         std::optional<movegen::Move> bestMove { std::nullopt };
         int32_t bestScore = s_minScore;
         uint16_t bestMoveIndex {};
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull() && moves[i].isCapture()) {
-                int32_t seeScore = evaluation::SeeSwap::run(board, moves[i]);
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull() && m_moves[i].isCapture()) {
+                int32_t seeScore = evaluation::SeeSwap::run(board, m_moves[i]);
 
                 if constexpr (isGood) {
                     if (seeScore >= 0 && seeScore > bestScore) {
-                        bestMove = moves[i];
+                        bestMove = m_moves[i];
                         bestScore = seeScore;
                         bestMoveIndex = i;
                     }
                 } else {
                     // Already eliminated good captures
                     if (seeScore > bestScore) {
-                        bestMove = moves[i];
+                        bestMove = m_moves[i];
                         bestScore = seeScore;
                         bestMoveIndex = i;
                     }
@@ -247,31 +282,31 @@ private:
             }
         }
         if (bestMove.has_value())
-            moves.nullifyMove(bestMoveIndex);
+            m_moves.nullifyMove(bestMoveIndex);
 
         return bestMove;
     }
 
     template<bool isGood>
-    constexpr std::optional<movegen::Move> pickPromotion(movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickPromotion()
     {
         if constexpr (isGood) {
             /* Currently, good captures are considered better than good promotions, and bad captures are worse than bad promotions */
-            for (uint16_t i = 0; i < moves.count(); i++) {
-                if (!moves[i].isNull() && moves[i].promotionType() == PromotionQueen && !moves[i].isCapture()) {
-                    const auto pickedMove = moves[i];
+            for (uint16_t i = 0; i < m_moves.count(); i++) {
+                if (!m_moves[i].isNull() && m_moves[i].promotionType() == PromotionQueen && !m_moves[i].isCapture()) {
+                    const auto pickedMove = m_moves[i];
 
-                    moves.nullifyMove(i);
+                    m_moves.nullifyMove(i);
 
                     return pickedMove;
                 }
             }
         } else {
-            for (uint16_t i = 0; i < moves.count(); i++) {
-                if (!moves[i].isNull() && moves[i].isPromotionMove() && !moves[i].isCapture()) {
-                    const auto pickedMove = moves[i];
+            for (uint16_t i = 0; i < m_moves.count(); i++) {
+                if (!m_moves[i].isNull() && m_moves[i].isPromotionMove() && !m_moves[i].isCapture()) {
+                    const auto pickedMove = m_moves[i];
 
-                    moves.nullifyMove(i);
+                    m_moves.nullifyMove(i);
 
                     return pickedMove;
                 }
@@ -281,18 +316,18 @@ private:
         return std::nullopt;
     }
 
-    constexpr std::optional<movegen::Move> pickKillerMove(KillerMoveType type, movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickKillerMove(KillerMoveType type)
     {
         const auto killerMoves = m_searchTables.getKillerMove(m_ply);
 
         const auto killerMove = type == KillerMoveType::First ? killerMoves.first : killerMoves.second;
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
 
-            if (!moves[i].isNull() && moves[i] == killerMove && moves[i].isQuietMove()) {
-                auto pickedMove = moves[i];
+            if (!m_moves[i].isNull() && m_moves[i] == killerMove && m_moves[i].isQuietMove()) {
+                auto pickedMove = m_moves[i];
 
-                moves.nullifyMove(i);
+                m_moves.nullifyMove(i);
 
                 return pickedMove;
             }
@@ -300,18 +335,18 @@ private:
         return std::nullopt;
     }
 
-    constexpr std::optional<movegen::Move> pickCounterMove(movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickCounterMove()
     {
         if (!m_prevMove.has_value())
             return std::nullopt;
 
         const auto counterMove = m_searchTables.getCounterMove(m_prevMove.value());
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull() && moves[i].isQuietMove() && moves[i] == counterMove) {
-                auto pickedMove = moves[i];
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull() && m_moves[i].isQuietMove() && m_moves[i] == counterMove) {
+                auto pickedMove = m_moves[i];
 
-                moves.nullifyMove(i);
+                m_moves.nullifyMove(i);
 
                 return pickedMove;
             }
@@ -320,20 +355,20 @@ private:
     }
 
     template<Player player>
-    constexpr std::optional<movegen::Move> pickHistoryMove(const BitBoard& board, movegen::ValidMoves& moves)
+    constexpr std::optional<movegen::Move> pickHistoryMove(const BitBoard& board)
     {
         int32_t bestScore = std::numeric_limits<int32_t>::min();
         std::optional<movegen::Move> bestMove = std::nullopt;
         uint16_t bestMoveIndex {};
 
-        for (uint16_t i = 0; i < moves.count(); i++) {
-            if (!moves[i].isNull() && moves[i].isQuietMove()) {
-                if (const auto attacker = board.getAttackerAtSquare<player>(moves[i].fromSquare())) {
-                    const int32_t score = m_searchTables.getHistoryMove(attacker.value(), moves[i].toPos());
+        for (uint16_t i = 0; i < m_moves.count(); i++) {
+            if (!m_moves[i].isNull() && m_moves[i].isQuietMove()) {
+                if (const auto attacker = board.getAttackerAtSquare<player>(m_moves[i].fromSquare())) {
+                    const int32_t score = m_searchTables.getHistoryMove(attacker.value(), m_moves[i].toPos());
 
                     if (score > bestScore) {
                         bestScore = score;
-                        bestMove = moves[i];
+                        bestMove = m_moves[i];
                         bestMoveIndex = i;
                     }
                 } else {
@@ -342,15 +377,18 @@ private:
             }
         }
         if (bestMove.has_value())
-            moves.nullifyMove(bestMoveIndex);
+            m_moves.nullifyMove(bestMoveIndex);
 
         return bestMove;
     }
 
     SearchTables& m_searchTables;
+
     uint8_t m_ply {};
+    PickerPhase m_phase { PickerPhase::TtMove };
     std::optional<movegen::Move> m_ttMove { std::nullopt };
     std::optional<movegen::Move> m_prevMove { std::nullopt };
-    PickerPhase m_phase { PickerPhase::TtMove };
+
+    movegen::ValidMoves m_moves {};
 };
 }

--- a/src/search/pv_table.h
+++ b/src/search/pv_table.h
@@ -75,9 +75,14 @@ public:
         return m_isScoring;
     }
 
-    bool isPvMove(movegen::Move move, uint8_t ply) const
+    inline bool isPvMove(movegen::Move move, uint8_t ply) const
     {
         return m_pvTable.at(0).at(ply) == move;
+    }
+
+    inline movegen::Move getPvMove(uint8_t ply) const
+    {
+        return m_pvTable.at(0).at(ply);
     }
 
     void updatePvScoring(const movegen::ValidMoves& moves, uint8_t ply)

--- a/tests/src/test_scoring.cpp
+++ b/tests/src/test_scoring.cpp
@@ -53,14 +53,11 @@ TEST_CASE("Scoring", "[scoring]")
             const auto board = parsing::FenParser::parse("1k6/8/8/4q3/3P4/8/n5n1/R6K w - - 0 0");
             REQUIRE(board.has_value());
 
-            movegen::ValidMoves moves;
-            core::getAllMoves<movegen::MoveCapture>(*board, moves);
-
             movegen::ValidMoves results {};
             SearchTables searchTables {};
-            MovePicker picker { searchTables, 0 };
+            MovePicker<movegen::MoveCapture> picker { searchTables, 0, PickerPhase::GenerateMoves };
 
-            while (const auto moveOpt = picker.pickNextMove(*board, moves)) {
+            while (const auto moveOpt = picker.pickNextMove(*board)) {
                 results.addMove(moveOpt.value());
             }
 
@@ -68,9 +65,6 @@ TEST_CASE("Scoring", "[scoring]")
             REQUIRE(getPiece(*board, results[0]) == WhitePawn);
             REQUIRE(getPiece(*board, results[1]) == WhiteKing);
             REQUIRE(getPiece(*board, results[2]) == WhiteRook);
-
-            // Reset nullified moves
-            core::getAllMoves<movegen::MoveCapture>(*board, moves);
 
             const auto move = s_evaluator.getBestMove(board.value(), 4);
             REQUIRE(getPiece(*board, move) == WhitePawn);
@@ -81,23 +75,17 @@ TEST_CASE("Scoring", "[scoring]")
             const auto board = parsing::FenParser::parse("1k6/6p1/7Q/4q3/3P4/8/n5n1/R6K w - - 0 0");
             REQUIRE(board.has_value());
 
-            movegen::ValidMoves moves;
-            core::getAllMoves<movegen::MovePseudoLegal>(*board, moves);
-
             movegen::ValidMoves results {};
             SearchTables searchTables {};
-            MovePicker picker { searchTables, 0 };
+            MovePicker<movegen::MovePseudoLegal> picker { searchTables, 0, PickerPhase::GenerateMoves };
 
-            while (const auto moveOpt = picker.pickNextMove(*board, moves)) {
+            while (const auto moveOpt = picker.pickNextMove(*board)) {
                 results.addMove(moveOpt.value());
             }
 
             REQUIRE(getPiece(*board, results[0]) == WhitePawn);
             REQUIRE(getPiece(*board, results[1]) == WhiteKing);
             REQUIRE(getPiece(*board, results[2]) == WhiteRook);
-
-            // Reset nullified moves
-            core::getAllMoves<movegen::MovePseudoLegal>(*board, moves);
 
             const auto move = s_evaluator.getBestMove(board.value(), 4);
             REQUIRE(getPiece(*board, move) == WhiteQueen); // evading attack + checking king = better move!


### PR DESCRIPTION
Move generation is currently happening in the searcher, but its only use is to be consumed by the picker.

This commit move the generation to the picker, which also will enable optimizations, e.g. staged move generation.

Bench 2389574