### PR TITLE
searcher: add insufficient material detection 

### DIFF
--- a/src/core/bit_board.h
+++ b/src/core/bit_board.h
@@ -121,6 +121,49 @@ struct BitBoard {
             return occupation[PlayerBlack] == (pieces[BlackPawn] | pieces[BlackKing]);
     }
 
+    inline bool hasInsufficientMaterial() const
+    {
+        /* cheapest check first - always sufficient material if more than 4 pieces */
+        const int totalPieces = std::popcount(occupation[Both]);
+        if (totalPieces > 4) {
+            return false;
+        }
+
+        /* if pawns or majors are on the board, there is always sufficient material */
+        const uint64_t majorsOrPawns = pieces[WhitePawn] | pieces[BlackPawn] | pieces[WhiteRook] | pieces[BlackRook] | pieces[WhiteQueen] | pieces[BlackQueen];
+        if (std::popcount(majorsOrPawns) != 0) {
+            return false;
+        }
+
+        if (totalPieces <= 2) {
+            /* only kings on the board */
+            return true;
+        }
+
+        if (totalPieces == 3) {
+            const uint64_t minors = pieces[WhiteBishop] | pieces[BlackBishop] | pieces[WhiteKnight] | pieces[BlackKnight];
+
+            /* one minor piece + kings is still a draw */
+            return std::popcount(minors) == 1;
+        }
+
+        if (totalPieces == 4) {
+            const uint64_t bishops = pieces[WhiteBishop] | pieces[BlackBishop];
+
+            /* check for exactly one bishop per side */
+            const bool oneWhiteBishop = std::popcount(pieces[WhiteBishop]) == 1;
+
+            /* check if bishops are on opposite color squares */
+            const bool bishopOnLight = std::popcount(s_lightSquares & bishops) == 1;
+            const bool bishopOnDark = std::popcount(s_darkSquares & bishops) == 1;
+
+            return oneWhiteBishop && bishopOnLight && bishopOnDark;
+        }
+
+        /* all other cases have potential for sufficient material */
+        return false;
+    }
+
     std::array<uint64_t, magic_enum::enum_count<Piece>()> pieces {};
     std::array<uint64_t, magic_enum::enum_count<Occupation>()> occupation {};
     std::array<uint64_t, magic_enum::enum_count<Player>()> attacks {};

--- a/src/core/board_defs.h
+++ b/src/core/board_defs.h
@@ -127,6 +127,9 @@ constexpr static inline uint8_t s_sixthRow { 40 };
 constexpr static inline uint8_t s_seventhRow { 48 };
 constexpr static inline uint8_t s_eightRow { 56 };
 
+constexpr static inline uint64_t s_lightSquares = { 0x5599559955995599 };
+constexpr static inline uint64_t s_darkSquares = { 0xaa66aa66aa66aa66 };
+
 constexpr static inline uint32_t s_maxMoves { 256 };
 constexpr static inline uint64_t s_aFileMask { 0x0101010101010101 };
 constexpr static inline uint64_t s_hFileMask { 0x8080808080808080 };

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -232,13 +232,9 @@ public:
 
         m_searchTables.updatePvLength(m_ply);
         if (m_ply) {
-            /* FIXME: make a little more sophisticated with material count etc */
-            const bool isDraw = m_repetition.isRepetition(m_stackItr->hash) || board.halfMoves >= 100;
-            if (isDraw) {
-                /* draw score is 0 but to avoid blindness towards three fold lines
-                 * we add a slight variance to the draw score
-                 * it will still be approx 0~ cp: [-0.1:0.1] */
-                return 1 - (m_nodes & 2); /* draw score */
+            const auto drawScore = checkForDraw(board);
+            if (drawScore.has_value()) {
+                return drawScore.value();
             }
         }
 
@@ -475,12 +471,9 @@ private:
         m_nodes++;
         m_selDepth = std::max(m_selDepth, m_ply);
 
-        const bool isDraw = m_repetition.isRepetition(m_stackItr->hash) || board.halfMoves >= 100;
-        if (isDraw) {
-            /* draw score is 0 but to avoid blindness towards three fold lines
-             * we add a slight variance to the draw score
-             * it will still be approx 0~ cp: [-0.1:0.1] */
-            return 1 - (m_nodes & 2); /* draw score */
+        const auto drawScore = checkForDraw(board);
+        if (drawScore.has_value()) {
+            return drawScore.value();
         }
 
         if (m_ply >= s_maxSearchDepth)
@@ -683,6 +676,19 @@ private:
         }
 
         return TimeManager::hasTimedOut();
+    }
+
+    inline std::optional<Score> checkForDraw(const BitBoard& board)
+    {
+        const bool isDraw = board.halfMoves >= 100 || m_repetition.isRepetition(m_stackItr->hash) || board.hasInsufficientMaterial();
+        if (isDraw) {
+            /* draw score is 0 but to avoid blindness towards three fold lines
+             * we add a slight variance to the draw score
+             * it will still be approx 0~ cp: [-0.1:0.1] */
+            return 1 - (m_nodes & 2); /* draw score */
+        }
+
+        return std::nullopt;
     }
 
     static inline uint8_t s_numSearchers {};


### PR DESCRIPTION
The real gains from the beta propagation lies eg. adding insufficient
material detection.

Making the engine material aware is a very important. And until now it
had always resulted in a elo loss. No more :)

Bench 2338567

```
Elo   | 37.98 +- 24.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 20.00]
Games | N: 450 W: 148 L: 99 D: 203
Penta | [11, 43, 86, 56, 29]
https://openbench.bunny.beer/test/341/
```

(note: test was performed with #140 so elo gain is with that included as well)