### PR TITLE
searcher: add improving heuristics

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -277,6 +277,9 @@ public:
         /* update current stack with the static evaluation */
         m_stackItr->eval = fetchOrStoreEval(board, hashProbe);
 
+        /* improving heuristics -> have the position improved since our last position? */
+        const bool isImproving = m_ply >= 2 && (m_stackItr - 2)->eval < m_stackItr->eval;
+
         /* static pruning - try to prove that the position is good enough to not need
          * searching the entire branch */
         if (!isPv && !isChecked) {
@@ -385,6 +388,7 @@ public:
                     reduction -= static_cast<int8_t>(isChecked); /* reduce less when checked */
                     reduction -= static_cast<int8_t>(isGivingCheck); /* reduce less when giving check */
                     reduction += static_cast<int8_t>(!isPv); /* reduce more when not pv line */
+                    reduction += static_cast<int8_t>(!isImproving); /* reduce more when not improving */
                     reduction += static_cast<int8_t>(cutNode); /* reduce more when cut-node */
 
                     reduction = std::clamp<uint8_t>(reduction, 0, depth - 1);


### PR DESCRIPTION
This commit adds initial "improving heuristics".

The improving heuristic is a scalar that can be appended to various other heuristics. Ie search less deep when not improving (not an important positition?) and maybe search deeper when improving (more important position?).

As a start simply append the improving heuristic to LMR where we can reduce the search depth if the position is not improving.

Bench 1678321

```
Elo   | 14.77 +- 7.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4024 W: 1234 L: 1063 D: 1727
Penta | [127, 432, 764, 521, 168]
https://openbench.bunny.beer/test/344/
```