### PR TITLE
terms: clean up terms | generalize compile time args

### DIFF
--- a/src/evaluation/term_methods.h
+++ b/src/evaluation/term_methods.h
@@ -54,6 +54,11 @@
 
 namespace evaluation {
 
+constexpr std::array<uint64_t, magic_enum::enum_count<Player>()> s_outpostRankMaks {
+    s_row4Mask | s_row5Mask | s_row6Mask,
+    s_row3Mask | s_row4Mask | s_row5Mask,
+};
+
 /* A context to precompute heavy operations so we don't have to do that
  * multiple times for a single evaluation
  * NOTE: Only values that are being reused between terms should be added here */
@@ -179,21 +184,11 @@ static inline TermScore getKnightScore(const BitBoard& board, TermContext& ctx, 
         ctx.pieceAttacks[player][Knight] = moves;
         ctx.threats[player] |= moves;
 
-        if constexpr (player == PlayerWhite) {
-            if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_whiteOutpostRankMask) {
-                const bool isOutside = square & (s_aFileMask | s_hFileMask);
-                const bool isDefended = square & pawnDefends;
+        if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_outpostRankMaks[player]) {
+            const bool isOutside = square & (s_aFileMask | s_hFileMask);
+            const bool isDefended = square & pawnDefends;
 
-                ADD_SCORE_INDEXED(knightOutpostScore, isOutside + (isDefended << 1));
-            }
-
-        } else {
-            if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_blackOutpostRankMask) {
-                const bool isOutside = square & (s_aFileMask | s_hFileMask);
-                const bool isDefended = square & pawnDefends;
-
-                ADD_SCORE_INDEXED(knightOutpostScore, isOutside + (isDefended << 1));
-            }
+            ADD_SCORE_INDEXED(knightOutpostScore, isOutside + (isDefended << 1));
         }
     });
 
@@ -247,20 +242,11 @@ static inline TermScore getBishopScore(const BitBoard& board, TermContext& ctx, 
         ctx.pieceAttacks[player][Bishop] = moves;
         ctx.threats[player] |= moves;
 
-        if constexpr (player == PlayerWhite) {
-            if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_whiteOutpostRankMask) {
-                const bool isOutside = square & (s_aFileMask | s_hFileMask);
-                const bool isDefended = square & pawnDefends;
+        if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_outpostRankMaks[player]) {
+            const bool isOutside = square & (s_aFileMask | s_hFileMask);
+            const bool isDefended = square & pawnDefends;
 
-                ADD_SCORE_INDEXED(bishopOutpostScore, isOutside + (isDefended << 1));
-            }
-        } else {
-            if (!(s_outpostSquareMaskTable[player][pos] & theirPawns) && square & s_blackOutpostRankMask) {
-                const bool isOutside = square & (s_aFileMask | s_hFileMask);
-                const bool isDefended = square & pawnDefends;
-
-                ADD_SCORE_INDEXED(bishopOutpostScore, isOutside + (isDefended << 1));
-            }
+            ADD_SCORE_INDEXED(bishopOutpostScore, isOutside + (isDefended << 1));
         }
     });
 

--- a/src/utils/bit_operations.h
+++ b/src/utils/bit_operations.h
@@ -78,5 +78,20 @@ static inline uint64_t pushForwardFromPos(BoardPosition pos)
     return pushForward<player>(square);
 }
 
+[[nodiscard]] constexpr inline BoardPosition flipPosition(BoardPosition pos) noexcept
+{
+    return static_cast<BoardPosition>(pos ^ 56);
+}
+
+template<Player player>
+constexpr inline BoardPosition relativePosition(BoardPosition pos) noexcept
+{
+    if constexpr (player == PlayerWhite) {
+        return pos;
+    } else {
+        return flipPosition(pos);
+    }
+}
+
 }
 


### PR DESCRIPTION
See each commit for details

```
Elo   | 0.09 +- 2.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27704 W: 7883 L: 7876 D: 11945
Penta | [847, 3080, 5984, 3101, 840]
https://openbench.bunny.beer/test/343/
```