### PR TITLE
transposition: don't overwrite tt moves

### DIFF
--- a/src/core/transposition.h
+++ b/src/core/transposition.h
@@ -135,12 +135,18 @@ public:
         auto& entry = s_table[key % s_tableSize];
         const auto entryKey = entry.key.load(std::memory_order_relaxed);
         const auto entryData = entry.data.load(std::memory_order_relaxed);
+        const bool sameKey = key == entryKey;
 
         /* only update entry if a better one is found */
-        if (key != entryKey
+        if (!sameKey
             || entryData.move.isNull()
             || depth >= entryData.depth
             || (flag == TtExact && entryData.flag != TtExact)) {
+
+            /* don't overwrite move if we have one stored! */
+            if (sameKey && move.isNull()) {
+                move = entryData.move;
+            }
 
             TtEntryData newData {
                 .depth = depth,


### PR DESCRIPTION
If we already have a move stored (ie a search write and not just a static eval write) then we might as well save that instead of overwriting with a null move.

This should lead to better move ordering.

Bench 1609705

```
Elo   | 38.85 +- 13.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1392 W: 442 L: 287 D: 663
Penta | [25, 141, 254, 206, 70]
https://openbench.bunny.beer/test/392/
```