### PR TITLE
Clara/combine picker phases

### DIFF
--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -80,8 +80,9 @@ public:
         int depth = 0;
         std::array<int32_t, 32> gain {}; // Stores gains for each exchange depth
 
-        /* piece that will track the scoring of next piece */
-        Piece nextPiece = board.getAttackerAtSquare(move.fromSquare(), board.player).value();
+        /* piece that will track the scoring of next piece
+         * NOTE: WhiteQueen is just a hack - white and black have same score */
+        Piece nextPiece = move.promotionType() == PromotionQueen ? WhiteQueen : board.getAttackerAtSquare(move.fromSquare(), board.player).value();
 
         Player player = board.player;
 


### PR DESCRIPTION
This commit combines promotions and captures into a single phase.
Promotions therefore benefit from pre-computation during scoring phase.

Captures are sorted by their SEE value, good promotions are assigned the
value of a queen in the SEE swap, and bad promotions are scored highly
negatively. The latter two are inlined, in order to preserve constexpr
of the queen SEE score and build for SPSA.

Tactical moves have also been renamed to 'noisy'.

Bench 2953743

https://openbench.bunny.beer/test/487/

```
Elo   | 1.48 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -3.06 (-2.94, 2.94) [0.00, 10.00]
```
