### PR TITLE
bench: increase default depth 8=>10

### DIFF
--- a/src/tools/bench.h
+++ b/src/tools/bench.h
@@ -63,7 +63,7 @@ public:
 
 private:
     static inline uint64_t s_nodesCount {};
-    constexpr static inline uint8_t s_defaultSearchDepth { 8 };
+    constexpr static inline uint8_t s_defaultSearchDepth { 10 };
 
     /* commonly used bench positions */
     constexpr static inline auto s_benchPositions = std::to_array<std::string_view>({


### PR DESCRIPTION
As we're starting to prune more aggresively our bench values are reaching a fairly low node count.
As some of our pruning is mostly active when searching deeper we will benefit from having these reflected in the bench. For eg quick sanity checks etc.

Therefore bump default depth from 8=>10

Bench 2896024