### PR TITLE
evaluation: add draw contempt factor

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -675,10 +675,7 @@ private:
     {
         const bool isDraw = board.halfMoves >= 100 || m_repetition.isRepetition(board, m_stackItr->board.hash, m_ply) || board.hasInsufficientMaterial();
         if (isDraw) {
-            /* draw score is 0 but to avoid blindness towards three fold lines
-             * we add a slight variance to the draw score
-             * it will still be approx 0~ cp: [-0.1:0.1] */
-            return 1 - (m_nodes & 2); /* draw score */
+            return m_staticEval.getDrawScore(m_nodes, m_ply);
         }
 
         return std::nullopt;


### PR DESCRIPTION
This commit adds "draw contempt" to our draw score. Draw contemt helps against drawing against weaker engines; don't go towards a draw when we might be able to win, but it also helps against stronger engines where we probably prefer going to a draw if possible.

Less draws => more wins (hopefully)

Bench 2931315

```
Elo   | 1.40 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.84 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42326 W: 12620 L: 12450 D: 17256
Penta | [1268, 4834, 8868, 4846, 1347]
https://openbench.bunny.beer/test/472/


this vs v1.7
Elo   | 197.62 +- 14.80 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 2004 W: 1294 L: 263 D: 447
Penta | [16, 53, 220, 310, 403]
https://openbench.bunny.beer/test/474/

main vs v1.7
Elo   | 186.49 +- 13.90 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 2006 W: 1242 L: 258 D: 506
Penta | [14, 49, 242, 335, 363]
https://openbench.bunny.beer/test/475/
```