### PR TITLE
searcher: add `isChecked` to negamax eval

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -247,11 +247,16 @@ public:
         /* is the position part of the current or a previous PV line? */
         const bool ttPv = isPv || (ttProbe.has_value() && ttProbe->info.pv());
 
-        /* update current stack with the static evaluation */
-        m_stackItr->eval = fetchOrStoreEval(board, ttProbe, ttPv);
+        if (isChecked) {
+            /* evaluation terms are not considering king being attacked */
+            m_stackItr->eval = -s_mateValue + m_ply;
+        } else {
+            /* update current stack with the static evaluation */
+            m_stackItr->eval = fetchOrStoreEval(board, ttProbe, ttPv);
+        }
 
         /* improving heuristics -> have the position improved since our last position? */
-        const bool isImproving = m_ply >= 2 && (m_stackItr - 2)->eval < m_stackItr->eval;
+        const bool isImproving = !isChecked && m_ply >= 2 && (m_stackItr - 2)->eval < m_stackItr->eval;
 
         /* static pruning - try to prove that the position is good enough to not need
          * searching the entire branch */


### PR DESCRIPTION
Our static evaluation is quite off when we're checked. It's a "lost" position no matter what, so we should reflect that in the evaluation.

The same goes for the "isImproving" - we're not in a better position if we're checked.

This fixes missing mating lines and in general a safer search.

NOTE: we already do the same in qsearch.

Bench 3113053

```
Elo   | 3.78 +- 4.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.35 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11312 W: 3125 L: 3002 D: 5185
Penta | [350, 1317, 2219, 1400, 370]
https://openbench.bunny.beer/test/496/
```