### PR TITLE
correction_history: add threat history

### DIFF
--- a/src/core/zobrist_hashing.h
+++ b/src/core/zobrist_hashing.h
@@ -73,6 +73,11 @@ constexpr auto s_playerKey = createPlayerKey();
 
 }
 
+constexpr static inline uint64_t splitMixHash(uint64_t value)
+{
+    return splitmix64(value);
+}
+
 constexpr static inline void hashPiece(Piece piece, BoardPosition pos, uint64_t& hash)
 {
     hash ^= s_pieceHashTable[piece][pos];

--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -38,6 +38,7 @@
     TUNABLE(aspirationWindow, uint8_t, 60, 10, 100, 5)               \
     TUNABLE(pawnCorrectionWeight, uint16_t, 250, 100, 500, 25)       \
     TUNABLE(materialCorrectionWeight, uint16_t, 1000, 500, 1500, 50) \
+    TUNABLE(threatCorrectionWeight, uint16_t, 500, 250, 1000, 25)    \
     TUNABLE(timeManIncFrac, uint16_t, 80, 1, 150, 5)                 \
     TUNABLE(timeManBaseFrac, uint16_t, 54, 1, 150, 5)                \
     TUNABLE(timeManLimitFrac, uint16_t, 78, 1, 150, 5)               \


### PR DESCRIPTION
Adds "threats" as correction as well.

The threat is basically a bitmask of pieces being attacked which are
being hashed using the same hash algorithm we use for zobrist.

This can corrected for in the same way as the other parameters.
Easy to add, nice little gain :)

Bench 3337853

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>

```
Elo   | 9.03 +- 5.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7158 W: 1973 L: 1787 D: 3398
Penta | [216, 845, 1309, 955, 254]
https://openbench.bunny.beer/test/506/
```