### PR TITLE
searcher: add extended futility pruning

### DIFF
--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -30,6 +30,10 @@
     TUNABLE(razorMarginShallow, Score, 138, 0, 250, 10)              \
     TUNABLE(razorMarginDeep, Score, 184, 0, 250, 10)                 \
     TUNABLE(razorDeepReductionLimit, uint8_t, 4, 0, 12, 1)           \
+    TUNABLE(efpBase, Score, 80, 0, 200, 10)                          \
+    TUNABLE(efpImproving, Score, 100, 0, 200, 10)                    \
+    TUNABLE(efpMargin, Score, 90, 0, 200, 10)                        \
+    TUNABLE(efpDepthLimit, uint8_t, 5, 0, 12, 1)                     \
     TUNABLE(nmpBaseMargin, int8_t, -110, -200, 0, 10)                \
     TUNABLE(nmpMarginFactor, uint8_t, 20, 0, 100, 5)                 \
     TUNABLE(nmpReductionBase, uint8_t, 5, 1, 12, 1)                  \


### PR DESCRIPTION
This commit adds initial static forward pruning.

The first pruning technique is called "extended futility pruning" (EFP). The theory here is that after searching a certain amount of nodes, if the evaluation is marginally worse than alpha then we can assume that we're not going to improve that with "bad moves".

The "bad moves" are currently filtering out quiets and bad promotions. We could be more aggresive and also filter bad captures, but let's keep it a bit safer for now.

This scheme also makes it easy to apply more types of static forward pruning.

Bench 2820965

```
Elo   | 11.16 +- 6.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5606 W: 1583 L: 1403 D: 2620
Penta | [169, 642, 1052, 720, 220]
https://openbench.bunny.beer/test/538/
```