### PR TITLE
searcher: improve qsearch return values | compensate for correction in qsearch | fix duplicate merge issue

### DIFF
--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -301,13 +301,6 @@ public:
                             if (newScore < beta)
                                 return (newScore > score) ? newScore : score;
                         }
-
-                        score += spsa::razorMarginDeep;
-                        if (score < beta && depth <= spsa::razorDeepReductionLimit) {
-                            const Score newScore = quiesence<isPv>(board, alpha, beta);
-                            if (newScore < beta)
-                                return (newScore > score) ? newScore : score;
-                        }
                     }
                 }
             }


### PR DESCRIPTION
See each commit :)

```
Elo   | 9.46 +- 7.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4406 W: 1163 L: 1043 D: 2200
Penta | [106, 526, 868, 548, 155]
https://openbench.bunny.beer/test/545/
```