### PR TITLE
movegen: add `MoveNoisy` type | searcher: use `MoveNoisy` in qsearch | move_picker: skip bad noisy moves

### DIFF
--- a/src/movegen/move_generation.h
+++ b/src/movegen/move_generation.h
@@ -24,7 +24,7 @@ constexpr static inline void generateKnightMoves(ValidMoves& validMoves, uint64_
                 const bool isCapture = utils::positionToSquare(pos) & theirOccupation;
                 validMoves.addMove(Move::create(from, pos, isCapture));
             });
-        } else if constexpr (type == MoveCapture) {
+        } else if constexpr (type == MoveCapture || type == MoveNoisy) {
             const uint64_t moves = getKnightMoves(from) & theirOccupation;
             utils::bitIterate(moves, [&](BoardPosition pos) {
                 validMoves.addMove(Move::create(from, pos, true));
@@ -45,7 +45,7 @@ constexpr static inline void generateRookMoves(ValidMoves& validMoves, uint64_t 
                 const bool isCapture = utils::positionToSquare(pos) & theirOccupation;
                 validMoves.addMove(Move::create(from, pos, isCapture));
             });
-        } else if constexpr (type == MoveCapture) {
+        } else if constexpr (type == MoveCapture || type == MoveNoisy) {
             const uint64_t moves = getRookMoves(from, ownOccupation | theirOccupation) & theirOccupation;
             utils::bitIterate(moves, [&](BoardPosition pos) {
                 validMoves.addMove(Move::create(from, pos, true));
@@ -66,7 +66,7 @@ constexpr static inline void generateBishopMoves(ValidMoves& validMoves, uint64_
                 const bool isCapture = utils::positionToSquare(pos) & theirOccupation;
                 validMoves.addMove(Move::create(from, pos, isCapture));
             });
-        } else if constexpr (type == MoveCapture) {
+        } else if constexpr (type == MoveCapture || type == MoveNoisy) {
             const uint64_t moves = getBishopMoves(from, ownOccupation | theirOccupation) & theirOccupation;
             utils::bitIterate(moves, [&](BoardPosition pos) {
                 validMoves.addMove(Move::create(from, pos, true));
@@ -94,7 +94,7 @@ constexpr static inline void generateKingMoves(ValidMoves& validMoves, uint64_t 
                 const bool isCapture = utils::positionToSquare(pos) & theirOccupation;
                 validMoves.addMove(Move::create(from, pos, isCapture));
             });
-        } else if constexpr (type == MoveCapture) {
+        } else if constexpr (type == MoveCapture || type == MoveNoisy) {
             const uint64_t moves = s_kingsTable.at(from) & theirOccupation & ~attacks;
             utils::bitIterate(moves, [&](BoardPosition pos) {
                 validMoves.addMove(Move::create(from, pos, true));
@@ -228,7 +228,7 @@ constexpr static inline void getPawnMoves(ValidMoves& validMoves, const BitBoard
 template<Player player, MoveType type>
 constexpr static inline void getCastlingMoves(ValidMoves& validMoves, const BitBoard& board, uint64_t attacks)
 {
-    if constexpr (type == MoveCapture) {
+    if constexpr (type == MoveCapture || type == MoveNoisy) {
         return;
     }
 

--- a/src/movegen/move_types.h
+++ b/src/movegen/move_types.h
@@ -10,6 +10,7 @@ namespace movegen {
 enum MoveType {
     MovePseudoLegal,
     MoveCapture,
+    MoveNoisy,
 };
 
 /* NOTE: all captures have 0b100 set

--- a/src/movegen/pawns.h
+++ b/src/movegen/pawns.h
@@ -68,7 +68,7 @@ constexpr static inline void getWhitePawnMoves(ValidMoves& validMoves, uint64_t 
     backtrackPawnMoves(validMoves, attackLeft, 7, true);
     backtrackPawnMoves(validMoves, attackRight, 9, true);
 
-    if constexpr (type == MovePseudoLegal) {
+    if constexpr (type == MovePseudoLegal || type == MoveNoisy) {
         uint64_t promoteStraight = ((pawns & s_row7Mask) << 8) & ~allOccupation;
         backtrackPawnPromotions(validMoves, promoteStraight, 8, false);
     }
@@ -99,7 +99,7 @@ constexpr static inline void getBlackPawnMoves(ValidMoves& validMoves, uint64_t 
     backtrackPawnMoves(validMoves, attackLeft, -9, true);
     backtrackPawnMoves(validMoves, attackRight, -7, true);
 
-    if constexpr (type == MovePseudoLegal) {
+    if constexpr (type == MovePseudoLegal || type == MoveNoisy) {
         uint64_t promoteStraight = ((pawns & s_row2Mask) >> 8) & ~allOccupation;
 
         backtrackPawnPromotions(validMoves, promoteStraight, -8, false);

--- a/src/search/move_picker.h
+++ b/src/search/move_picker.h
@@ -48,7 +48,9 @@ public:
         , m_ttMove(ttMove)
         , m_prevMove(prevMove)
     {
-        if constexpr (moveType == movegen::MoveCapture) {
+        if constexpr (moveType == movegen::MoveCapture || moveType == movegen::MoveNoisy) {
+            m_skipQuiets = true;
+
             if (m_ttMove && !m_ttMove->isCapture())
                 m_ttMove.reset();
         }

--- a/src/search/move_picker.h
+++ b/src/search/move_picker.h
@@ -127,7 +127,12 @@ public:
             if (const auto pickedMove = pickNoisyMove<true>())
                 return pickedMove;
 
-            m_phase = PickerPhase::GenerateQuietScores;
+            /* when running qsearch we don't want to search bad noisy - so just go straight to done */
+            if constexpr (moveType == movegen::MoveNoisy || moveType == movegen::MoveCapture) {
+                m_phase = PickerPhase::Done;
+            } else {
+                m_phase = PickerPhase::GenerateQuietScores;
+            }
 
             return pickNextMove<player>(board);
         }

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -557,6 +557,7 @@ private:
 
         const auto ttMove = tryFetchTtMove(ttProbe);
 
+        /* noisy picker auto prunes bad noisy - no need to handle it here */
         MovePicker<movegen::MoveNoisy> picker { m_searchTables, m_ply, PickerPhase::GenerateMoves, ttMove };
 
         while (const auto& moveOpt = picker.pickNextMove(board)) {

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -557,7 +557,7 @@ private:
 
         const auto ttMove = tryFetchTtMove(ttProbe);
 
-        MovePicker<movegen::MoveCapture> picker { m_searchTables, m_ply, PickerPhase::GenerateMoves, ttMove };
+        MovePicker<movegen::MoveNoisy> picker { m_searchTables, m_ply, PickerPhase::GenerateMoves, ttMove };
 
         while (const auto& moveOpt = picker.pickNextMove(board)) {
             const auto move = moveOpt.value();


### PR DESCRIPTION
See each commit for details :)

Closes #172 

```
Elo   | 20.05 +- 6.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 2.00]
Games | N: 6904 W: 2148 L: 1750 D: 3006
Penta | [226, 739, 1207, 971, 309]
https://openbench.bunny.beer/test/547/
```