### PR TITLE
see_swap: correct lva | correct promotion scores | correct en-pessant score

### DIFF
--- a/src/core/board_defs.h
+++ b/src/core/board_defs.h
@@ -102,6 +102,24 @@ constexpr inline char promotionToString(PromotionType p)
     return ' ';
 }
 
+constexpr inline std::optional<ColorlessPiece> promotionToColorlessPiece(PromotionType promotion)
+{
+    switch (promotion) {
+    case PromotionNone:
+        break;
+    case PromotionQueen:
+        return Queen;
+    case PromotionKnight:
+        return Knight;
+    case PromotionBishop:
+        return Bishop;
+    case PromotionRook:
+        return Rook;
+    }
+
+    return std::nullopt;
+}
+
 constexpr static inline uint8_t s_amountPieces = magic_enum::enum_count<Piece>();
 
 enum Phases : uint8_t {

--- a/src/core/move_handling.h
+++ b/src/core/move_handling.h
@@ -197,6 +197,25 @@ constexpr static inline BoardPosition enpessantCapturePosition(BoardPosition pos
 }
 
 template<Player player>
+constexpr static inline uint64_t enpessantCaptureSquare(uint64_t square)
+{
+    if constexpr (player == PlayerWhite) {
+        return square >> 8;
+    } else {
+        return square << 8;
+    }
+}
+
+constexpr static inline uint64_t enpessantCaptureSquare(uint64_t square, Player player)
+{
+    if (player == PlayerWhite) {
+        return enpessantCaptureSquare<PlayerWhite>(square);
+    } else {
+        return enpessantCaptureSquare<PlayerBlack>(square);
+    }
+}
+
+template<Player player>
 constexpr void performEnpessantMove(BitBoard& newBoard, movegen::Move move)
 {
     constexpr Piece ourPawn = player == PlayerWhite ? WhitePawn : BlackPawn;

--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -131,27 +131,29 @@ private:
             | (movegen::getKingMoves(target) & kings);
     }
 
-    constexpr static inline std::optional<Piece> getLeastValuableAttacker(const BitBoard& board, uint64_t attackers, uint64_t& occ, Player player)
+    template<Player player>
+    constexpr static inline std::optional<Piece> getLeastValuableAttacker(const BitBoard& board, uint64_t attackers, uint64_t& occ)
     {
-        if (player == PlayerWhite) {
-            for (const auto piece : s_whitePieces) {
-                uint64_t subset = attackers & occ & board.pieces[piece];
-                if (subset) {
-                    occ &= ~subset; /* clear the piece we just found */
-                    return piece;
-                }
-            }
-        } else {
-            for (const auto piece : s_blackPieces) {
-                uint64_t subset = attackers & occ & board.pieces[piece];
-                if (subset) {
-                    occ &= ~subset; /* clear the piece we just found */
-                    return piece;
-                }
+        constexpr auto pieces = player == PlayerWhite ? s_whitePieces : s_blackPieces;
+
+        for (const auto piece : pieces) {
+            uint64_t subset = attackers & occ & board.pieces[piece];
+            if (subset) {
+                occ &= ~utils::lsbToSquare(subset); /* clear the piece we just found */
+                return piece;
             }
         }
 
         return std::nullopt; /* attackers must be empty */
+    }
+
+    constexpr static inline std::optional<Piece> getLeastValuableAttacker(const BitBoard& board, uint64_t attackers, uint64_t& occ, Player player)
+    {
+        if (player == PlayerWhite) {
+            return getLeastValuableAttacker<PlayerWhite>(board, attackers, occ);
+        } else {
+            return getLeastValuableAttacker<PlayerBlack>(board, attackers, occ);
+        }
     }
 
     constexpr static inline auto s_whitePawnTable = generatePawnTable<PlayerWhite>();

--- a/src/utils/bit_operations.h
+++ b/src/utils/bit_operations.h
@@ -48,6 +48,11 @@ constexpr uint8_t relativeRow(BoardPosition pos)
     return static_cast<BoardPosition>(std::countr_zero(piece));
 }
 
+[[nodiscard]] constexpr inline uint64_t lsbToSquare(uint64_t piece) noexcept
+{
+    return 1ULL << std::countr_zero(piece);
+}
+
 /* iterates over each set bit in the bitboard `data` and calls `fnc` with the corresponding BoardPosition
  * `fnc` is invoked once per set bit, with the position of the least significant bit */
 template<typename Func>


### PR DESCRIPTION
See each commit :)

```
Elo   | 6.16 +- 4.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11048 W: 2873 L: 2677 D: 5498
Penta | [268, 1370, 2126, 1418, 342]
https://openbench.bunny.beer/test/550/
```