### PR TITLE
spsa: apply tuning from `spsa 12-07-25`

### DIFF
--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -21,45 +21,45 @@
  *   - Create either immutable or mutable engine parameters
  *
  * For more details, see: src/spsa/README.md */
-#define TUNABLE_LIST(TUNABLE)                                        \
-    TUNABLE(fullDepthMove, uint8_t, 2, 1, 12, 1)                     \
-    TUNABLE(rfpReductionLimit, uint8_t, 6, 0, 12, 1)                 \
-    TUNABLE(rfpMargin, Score, 102, 0, 150, 10)                       \
-    TUNABLE(rfpEvaluationMargin, Score, 119, 0, 150, 10)             \
-    TUNABLE(razorReductionLimit, uint8_t, 3, 0, 12, 1)               \
-    TUNABLE(razorMarginShallow, Score, 138, 0, 250, 10)              \
-    TUNABLE(razorMarginDeep, Score, 184, 0, 250, 10)                 \
-    TUNABLE(razorDeepReductionLimit, uint8_t, 4, 0, 12, 1)           \
-    TUNABLE(efpBase, Score, 80, 0, 200, 10)                          \
-    TUNABLE(efpImproving, Score, 100, 0, 200, 10)                    \
-    TUNABLE(efpMargin, Score, 90, 0, 200, 10)                        \
-    TUNABLE(efpDepthLimit, uint8_t, 5, 0, 12, 1)                     \
-    TUNABLE(nmpBaseMargin, int8_t, -110, -200, 0, 10)                \
-    TUNABLE(nmpMarginFactor, uint8_t, 20, 0, 100, 5)                 \
-    TUNABLE(nmpReductionBase, uint8_t, 5, 1, 12, 1)                  \
-    TUNABLE(nmpReductionFactor, uint8_t, 4, 1, 12, 1)                \
-    TUNABLE(iirDepthLimit, uint8_t, 2, 2, 12, 1)                     \
-    TUNABLE(lmpDepthLimit, uint8_t, 10, 1, 15, 1)                    \
-    TUNABLE(lmpBase, uint64_t, 10, 0, 15, 1)                         \
-    TUNABLE(lmpMargin, uint64_t, 3, 1, 10, 1)                        \
-    TUNABLE(lmpImproving, uint64_t, 0, 0, 5, 1)                      \
-    TUNABLE(aspirationWindow, uint8_t, 60, 10, 100, 5)               \
-    TUNABLE(pawnCorrectionWeight, uint16_t, 250, 100, 500, 25)       \
-    TUNABLE(materialCorrectionWeight, uint16_t, 1000, 500, 1500, 50) \
-    TUNABLE(threatCorrectionWeight, uint16_t, 500, 250, 1000, 25)    \
-    TUNABLE(timeManIncFrac, uint16_t, 80, 1, 150, 5)                 \
-    TUNABLE(timeManBaseFrac, uint16_t, 54, 1, 150, 5)                \
-    TUNABLE(timeManLimitFrac, uint16_t, 78, 1, 150, 5)               \
-    TUNABLE(timeManSoftFrac, uint16_t, 49, 1, 150, 5)                \
-    TUNABLE(timeManHardFrac, uint16_t, 316, 100, 500, 20)            \
-    TUNABLE(timeManNodeFracBase, uint8_t, 145, 1, 200, 10)           \
-    TUNABLE(timeManNodeFracMultiplier, uint8_t, 187, 1, 200, 10)     \
-    TUNABLE(timeManScoreMargin, uint8_t, 9, 1, 20, 1)                \
-    TUNABLE(seePawnValue, int32_t, 112, 50, 200, 5)                  \
-    TUNABLE(seeKnightValue, int32_t, 412, 200, 600, 10)              \
-    TUNABLE(seeBishopValue, int32_t, 433, 200, 600, 10)              \
-    TUNABLE(seeRookValue, int32_t, 638, 400, 1000, 10)               \
-    TUNABLE(seeQueenValue, int32_t, 1010, 800, 1500, 10)
+#define TUNABLE_LIST(TUNABLE)                                       \
+    TUNABLE(fullDepthMove, uint8_t, 2, 1, 12, 1)                    \
+    TUNABLE(rfpReductionLimit, uint8_t, 6, 0, 12, 1)                \
+    TUNABLE(rfpMargin, Score, 90, 0, 150, 10)                       \
+    TUNABLE(rfpEvaluationMargin, Score, 81, 0, 150, 10)             \
+    TUNABLE(razorReductionLimit, uint8_t, 2, 0, 12, 1)              \
+    TUNABLE(razorMarginShallow, Score, 127, 0, 250, 10)             \
+    TUNABLE(razorMarginDeep, Score, 193, 0, 250, 10)                \
+    TUNABLE(razorDeepReductionLimit, uint8_t, 5, 0, 12, 1)          \
+    TUNABLE(efpBase, Score, 76, 0, 200, 10)                         \
+    TUNABLE(efpImproving, Score, 120, 0, 200, 10)                   \
+    TUNABLE(efpMargin, Score, 89, 0, 200, 10)                       \
+    TUNABLE(efpDepthLimit, uint8_t, 6, 0, 12, 1)                    \
+    TUNABLE(nmpBaseMargin, int8_t, -105, -200, 0, 10)               \
+    TUNABLE(nmpMarginFactor, uint8_t, 23, 0, 100, 5)                \
+    TUNABLE(nmpReductionBase, uint8_t, 5, 1, 12, 1)                 \
+    TUNABLE(nmpReductionFactor, uint8_t, 4, 1, 12, 1)               \
+    TUNABLE(iirDepthLimit, uint8_t, 3, 2, 12, 1)                    \
+    TUNABLE(lmpDepthLimit, uint8_t, 11, 1, 15, 1)                   \
+    TUNABLE(lmpBase, uint64_t, 9, 0, 15, 1)                         \
+    TUNABLE(lmpMargin, uint64_t, 3, 1, 10, 1)                       \
+    TUNABLE(lmpImproving, uint64_t, 1, 0, 5, 1)                     \
+    TUNABLE(aspirationWindow, uint8_t, 60, 10, 100, 5)              \
+    TUNABLE(pawnCorrectionWeight, uint16_t, 268, 100, 500, 25)      \
+    TUNABLE(materialCorrectionWeight, uint16_t, 884, 500, 1500, 50) \
+    TUNABLE(threatCorrectionWeight, uint16_t, 521, 250, 1000, 25)   \
+    TUNABLE(timeManIncFrac, uint16_t, 89, 1, 150, 5)                \
+    TUNABLE(timeManBaseFrac, uint16_t, 53, 1, 150, 5)               \
+    TUNABLE(timeManLimitFrac, uint16_t, 82, 1, 150, 5)              \
+    TUNABLE(timeManSoftFrac, uint16_t, 49, 1, 150, 5)               \
+    TUNABLE(timeManHardFrac, uint16_t, 331, 100, 500, 20)           \
+    TUNABLE(timeManNodeFracBase, uint8_t, 146, 1, 200, 10)          \
+    TUNABLE(timeManNodeFracMultiplier, uint8_t, 200, 1, 200, 10)    \
+    TUNABLE(timeManScoreMargin, uint8_t, 9, 1, 20, 1)               \
+    TUNABLE(seePawnValue, int32_t, 115, 50, 200, 5)                 \
+    TUNABLE(seeKnightValue, int32_t, 403, 200, 600, 10)             \
+    TUNABLE(seeBishopValue, int32_t, 432, 200, 600, 10)             \
+    TUNABLE(seeRookValue, int32_t, 653, 400, 1000, 10)              \
+    TUNABLE(seeQueenValue, int32_t, 1006, 800, 1500, 10)
 
 #ifdef SPSA
 


### PR DESCRIPTION
Applies the tuning from https://openbench.bunny.beer/tune/541/

Bench 1415419

```
Elo   | 25.11 +- 10.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2190 W: 645 L: 487 D: 1058
Penta | [54, 226, 410, 318, 87]
https://openbench.bunny.beer/test/552/
```