### PR TITLE
move_picker: swap-and-reduce for TT move

### DIFF
--- a/src/movegen/move_types.h
+++ b/src/movegen/move_types.h
@@ -267,11 +267,6 @@ public:
         m_moves[m_count++] = std::move(move);
     }
 
-    void nullifyMove(uint32_t i)
-    {
-        m_moves.at(i) = nullMove();
-    }
-
     Move* begin()
     {
         return m_moves.begin();


### PR DESCRIPTION
Instead of leaving null 'holes' in the move picker, we move picked moves to the back of the array of all moves and reduce the size accordingly.

Bench has changed, because quiet moves at the root have no history, and therefore picked in their order of generation. So changing the move order has large effects down the search.

https://openbench.bunny.beer/test/564/

Bench 1513294