### PR TITLE
see_swap: fix initial and promotion score

### DIFF
--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -53,16 +53,13 @@ public:
 
         /* subtract pawn from promotion value */
         if (promotionPiece.has_value()) {
-            gain[depth] -= s_pieceValues[Pawn];
+            gain[depth] += s_pieceValues[*promotionPiece] - s_pieceValues[Pawn];
         }
 
         /* intial attack mask based on our "new board occupation" */
-        uint64_t attackers = getAttackers(board, target, occ);
+        uint64_t attackers = getAttackers(board, target, occ) & occ;
 
-        if (attackers == 0)
-            return 0; // No attackers, no exchanges
-
-        while (attackers) {
+        while (true) {
             depth++;
 
             player = nextPlayer(player);
@@ -75,7 +72,7 @@ public:
             nextPiece = *piece;
 
             /* update attackers after removing captured piece */
-            attackers = getAttackers(board, target, occ);
+            attackers = getAttackers(board, target, occ) & occ;
         }
 
         /* Backtrack the sequence and evaluate the score */

--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -55,11 +55,11 @@
     TUNABLE(timeManNodeFracBase, uint8_t, 146, 1, 200, 10)          \
     TUNABLE(timeManNodeFracMultiplier, uint8_t, 200, 1, 200, 10)    \
     TUNABLE(timeManScoreMargin, uint8_t, 9, 1, 20, 1)               \
-    TUNABLE(seePawnValue, int32_t, 115, 50, 200, 5)                 \
-    TUNABLE(seeKnightValue, int32_t, 403, 200, 600, 10)             \
-    TUNABLE(seeBishopValue, int32_t, 432, 200, 600, 10)             \
-    TUNABLE(seeRookValue, int32_t, 653, 400, 1000, 10)              \
-    TUNABLE(seeQueenValue, int32_t, 1006, 800, 1500, 10)
+    TUNABLE(seePawnValue, int32_t, 100, 50, 200, 5)                 \
+    TUNABLE(seeKnightValue, int32_t, 300, 200, 500, 10)             \
+    TUNABLE(seeBishopValue, int32_t, 300, 200, 500, 10)             \
+    TUNABLE(seeRookValue, int32_t, 500, 350, 750, 10)               \
+    TUNABLE(seeQueenValue, int32_t, 900, 750, 1150, 10)
 
 #ifdef SPSA
 


### PR DESCRIPTION
Previously we had two issues:

1. we returned 0 when no counter attackers. Here we should return the gain of no counter attacks.
2. Promotion score was off - we didn't add the gain of the promoted piece. As the SEE values are off by our tuning I've reset these to primitive values. They'll be adjusted in next spsa tuning.

Bench 1410566

```
Elo   | 5.17 +- 3.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14102 W: 3563 L: 3353 D: 7186
Penta | [362, 1657, 2853, 1767, 412]
https://openbench.bunny.beer/test/596/
```