### PR TITLE
searcher: add see pruning

### DIFF
--- a/src/evaluation/score.h
+++ b/src/evaluation/score.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <optional>
 
@@ -50,4 +51,10 @@ constexpr inline std::optional<int8_t> scoreMateDistance(int16_t score)
     }
 
     return std::nullopt;
+}
+
+constexpr inline bool scoreIsMate(Score score)
+{
+    const Score absScore = std::abs(score);
+    return absScore > s_mateScore && absScore < s_mateValue;
 }

--- a/src/evaluation/see_swap.h
+++ b/src/evaluation/see_swap.h
@@ -17,7 +17,78 @@ namespace evaluation {
 
 class SeeSwap {
 public:
-    static inline int32_t run(const BitBoard& board, movegen::Move move)
+    static inline bool isGreaterThanMargin(const BitBoard& board, movegen::Move move, int32_t margin)
+    {
+        if (move.isCastleMove()) {
+            return margin >= 0;
+        }
+
+        /* as we're comparing with margin we can simplify handling by comparing to zero instead */
+        int32_t balance = -margin;
+
+        Player player = board.player;
+        const uint64_t fromSquare = move.fromSquare();
+        const uint64_t toSquare = move.toSquare();
+
+        /* the position we are operation on - all attacks will be targeted here */
+        const BoardPosition target = move.toPos();
+
+        const auto promotionPiece = promotionToColorlessPiece(move.promotionType());
+
+        /* piece that will track the scoring of next piece */
+        Piece nextPiece = promotionPiece.has_value()
+            ? static_cast<Piece>(promotionPiece.value())
+            : board.getAttackerAtSquare(fromSquare, board.player).value();
+
+        /* remove our current move's piece - it's "assumed" to already have been moved to the target square */
+        uint64_t occ = (board.occupation[Both] & ~fromSquare) | toSquare;
+
+        if (move.takeEnPessant()) {
+            occ &= ~core::enpessantCaptureSquare(toSquare, board.player);
+            balance += s_pieceValues[Pawn];
+        } else if (move.isCapture()) {
+            const Piece target = board.getTargetAtSquare(toSquare, board.player).value();
+            balance += s_pieceValues[target];
+        }
+
+        if (promotionPiece.has_value()) {
+            balance += s_pieceValues[*promotionPiece] - s_pieceValues[Pawn];
+        }
+
+        /* intial attack mask based on our "new board occupation" */
+        uint64_t attackers = getAttackers(board, target, occ) & occ;
+
+        while (true) {
+            player = nextPlayer(player);
+            if ((player == board.player && balance >= 0) || (player != board.player && balance <= 0)) {
+                break;
+            }
+
+            const auto piece = getLeastValuableAttacker(board, attackers, occ, player);
+            if (!piece.has_value())
+                break; /* no more attackers */
+
+            /* illegal position if king is attacked after capturing */
+            if (utils::isKing(*piece) && ((attackers & occ & board.occupation[nextPlayer(board.player)]) != 0)) {
+                break;
+            }
+
+            if (player == board.player) {
+                balance += s_pieceValues[nextPiece];
+            } else {
+                balance -= s_pieceValues[nextPiece];
+            }
+
+            /* update attackers after removing captured piece */
+            attackers = getAttackers(board, target, occ) & occ;
+            nextPiece = *piece;
+        }
+
+        return balance >= 0;
+    }
+
+    /* FIXME: use capture history as margin and replace with above */
+    static inline int32_t getCaptureScore(const BitBoard& board, movegen::Move move)
     {
         /* currently only works for captures */
         assert(move.isCapture());
@@ -40,7 +111,7 @@ public:
             : board.getAttackerAtSquare(fromSquare, board.player).value();
 
         /* remove our current move's piece - it's "assumed" to already have been moved to the target square */
-        uint64_t occ = board.occupation[Both] & ~fromSquare;
+        uint64_t occ = (board.occupation[Both] & ~fromSquare) | toSquare;
 
         /* we need to clear en-pessant manually as the capture square is different from the target square */
         if (move.takeEnPessant()) {
@@ -109,7 +180,7 @@ private:
         constexpr auto pieces = player == PlayerWhite ? s_whitePieces : s_blackPieces;
 
         for (const auto piece : pieces) {
-            uint64_t subset = attackers & occ & board.pieces[piece];
+            uint64_t subset = attackers & board.pieces[piece];
             if (subset) {
                 occ &= ~utils::lsbToSquare(subset); /* clear the piece we just found */
                 return piece;

--- a/src/movegen/move_types.h
+++ b/src/movegen/move_types.h
@@ -237,12 +237,12 @@ public:
         return data == 0;
     }
 
-private:
     constexpr inline MoveFlag getFlag() const
     {
         return static_cast<MoveFlag>((data >> s_flagShift) & s_flagMask);
     }
 
+private:
     constexpr static inline uint16_t s_toFromMask { 0b111111 }; /* 64 values */
     constexpr static inline uint8_t s_toShift { 6 };
 

--- a/src/search/move_picker.h
+++ b/src/search/move_picker.h
@@ -56,6 +56,11 @@ public:
         }
     }
 
+    inline PickerPhase getPhase() const
+    {
+        return m_phase;
+    }
+
     /* if enabled -> will skip quiets and bad promotions -> moves that are expected
      * to not be "super good" */
     inline void setSkipQuiets(bool enabled)
@@ -228,7 +233,7 @@ private:
     {
         for (uint16_t i = 0; i < m_tail; i++) {
             if (m_moves[i].isCapture()) {
-                m_scores[i] = evaluation::SeeSwap::run(board, m_moves[i]);
+                m_scores[i] = evaluation::SeeSwap::getCaptureScore(board, m_moves[i]);
             } else if (m_moves[i].promotionType() == PromotionQueen) {
                 m_scores[i] = spsa::seeQueenValue;
             } else if (m_moves[i].isPromotionMove()) {

--- a/src/search/searcher.h
+++ b/src/search/searcher.h
@@ -354,6 +354,8 @@ public:
         movegen::Move bestMove {};
         Score bestScore = s_minScore;
         uint64_t movesSearched = 0;
+        const Score seeQuietMargin = spsa::seeQuietMargin * depth;
+        const Score seeNoisyMargin = spsa::seeNoisyMargin * depth * depth;
 
         const auto prevMove = isRoot ? std::nullopt : std::make_optional((m_stackItr - 1)->move);
         MovePicker<movegen::MovePseudoLegal> picker(m_searchTables, m_ply, phase, ttMove, prevMove);
@@ -379,6 +381,22 @@ public:
                     /* Late move pruning: https://www.madchess.net/2020/02/08/madchess-3-0-beta-4478cb8-late-move-pruning/ */
                     if (depth <= spsa::lmpDepthLimit && movesSearched >= lmpMaxMoves) {
                         picker.setSkipQuiets(true);
+                    }
+                }
+            }
+
+            if constexpr (!isRoot) {
+                /* skip this branch if SEE determines the static exchange results in a significant material loss */
+                const bool moveHasQuietFlag = move.getFlag() == movegen::MoveFlag::Quiet;
+                if (movesSearched > 0
+                    && !isChecked
+                    && depth <= spsa::seeDepthLimit
+                    && (move.isNoisyMove() || moveHasQuietFlag)
+                    && picker.getPhase() > PickerPhase::NoisyGood
+                    && !scoreIsMate(bestScore)) {
+                    const Score margin = moveHasQuietFlag ? -seeQuietMargin : -seeNoisyMargin;
+                    if (!evaluation::SeeSwap::isGreaterThanMargin(board, move, margin)) {
+                        continue;
                     }
                 }
             }

--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -43,6 +43,9 @@
     TUNABLE(lmpBase, uint64_t, 9, 0, 15, 1)                         \
     TUNABLE(lmpMargin, uint64_t, 3, 1, 10, 1)                       \
     TUNABLE(lmpImproving, uint64_t, 1, 0, 5, 1)                     \
+    TUNABLE(seeQuietMargin, uint8_t, 65, 0, 200, 10)                \
+    TUNABLE(seeNoisyMargin, uint8_t, 25, 0, 100, 5)                 \
+    TUNABLE(seeDepthLimit, uint8_t, 10, 0, 15, 1)                   \
     TUNABLE(aspirationWindow, uint8_t, 60, 10, 100, 5)              \
     TUNABLE(pawnCorrectionWeight, uint16_t, 268, 100, 500, 25)      \
     TUNABLE(materialCorrectionWeight, uint16_t, 884, 500, 1500, 50) \

--- a/src/utils/bit_operations.h
+++ b/src/utils/bit_operations.h
@@ -130,4 +130,9 @@ constexpr inline bool isKing(Piece piece)
     }
 }
 
+constexpr inline bool isKing(Piece piece)
+{
+    return piece == WhiteKing || piece == BlackKing;
+}
+
 }

--- a/tests/src/test_see_swap.cpp
+++ b/tests/src/test_see_swap.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Test See Swap", "[SeeSwap]")
         core::getAllMoves<movegen::MoveCapture>(*board, moves);
         REQUIRE(moves.count() == 1);
 
-        Score score = evaluation::SeeSwap::run(*board, moves[0]);
+        Score score = evaluation::SeeSwap::getCaptureScore(*board, moves[0]);
         REQUIRE(score == spsa::seePawnValue);
     }
 
@@ -48,7 +48,7 @@ TEST_CASE("Test See Swap", "[SeeSwap]")
         REQUIRE(getPiece(*board, *move) == WhiteKnight);
         REQUIRE(move->toPos() == E5);
 
-        Score score = evaluation::SeeSwap::run(*board, *move);
+        Score score = evaluation::SeeSwap::getCaptureScore(*board, *move);
         REQUIRE(score == (spsa::seePawnValue - spsa::seeKnightValue));
     }
 }


### PR DESCRIPTION
SEE pruning is an attempt at pruning branches by evaluating the worst/best case scenario in a simplified way.

If the SEE score is significantly low then we can assume that the given branch is not worth searching.

This implementation is very similar to our capture score but here we just compute a balance - and quiet moves are also accepted.

Bench 1209330

```
Elo   | 7.16 +- 3.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 2.00]
Games | N: 19080 W: 4874 L: 4481 D: 9725
Penta | [510, 2212, 3803, 2405, 610]
https://openbench.bunny.beer/test/613/
```