### PR TITLE
spsa: apply parameters from 23-08-25 tuning

### DIFF
--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -23,46 +23,46 @@
  * For more details, see: src/spsa/README.md */
 #define TUNABLE_LIST(TUNABLE)                                       \
     TUNABLE(fullDepthMove, uint8_t, 2, 1, 12, 1)                    \
-    TUNABLE(rfpReductionLimit, uint8_t, 6, 0, 12, 1)                \
-    TUNABLE(rfpMargin, Score, 90, 0, 150, 10)                       \
-    TUNABLE(rfpEvaluationMargin, Score, 81, 0, 150, 10)             \
+    TUNABLE(rfpReductionLimit, uint8_t, 11, 0, 12, 1)               \
+    TUNABLE(rfpMargin, Score, 92, 0, 150, 10)                       \
+    TUNABLE(rfpEvaluationMargin, Score, 45, 0, 150, 10)             \
     TUNABLE(razorReductionLimit, uint8_t, 2, 0, 12, 1)              \
-    TUNABLE(razorMarginShallow, Score, 127, 0, 250, 10)             \
-    TUNABLE(razorMarginDeep, Score, 193, 0, 250, 10)                \
-    TUNABLE(razorDeepReductionLimit, uint8_t, 5, 0, 12, 1)          \
-    TUNABLE(efpBase, Score, 76, 0, 200, 10)                         \
-    TUNABLE(efpImproving, Score, 120, 0, 200, 10)                   \
-    TUNABLE(efpMargin, Score, 89, 0, 200, 10)                       \
-    TUNABLE(efpDepthLimit, uint8_t, 6, 0, 12, 1)                    \
-    TUNABLE(nmpBaseMargin, int8_t, -105, -200, 0, 10)               \
-    TUNABLE(nmpMarginFactor, uint8_t, 23, 0, 100, 5)                \
-    TUNABLE(nmpReductionBase, uint8_t, 5, 1, 12, 1)                 \
+    TUNABLE(razorMarginShallow, Score, 103, 0, 250, 10)             \
+    TUNABLE(razorMarginDeep, Score, 187, 0, 250, 10)                \
+    TUNABLE(razorDeepReductionLimit, uint8_t, 2, 0, 12, 1)          \
+    TUNABLE(efpBase, Score, 77, 0, 200, 10)                         \
+    TUNABLE(efpImproving, Score, 117, 0, 200, 10)                   \
+    TUNABLE(efpMargin, Score, 56, 0, 200, 10)                       \
+    TUNABLE(efpDepthLimit, uint8_t, 8, 0, 12, 1)                    \
+    TUNABLE(nmpBaseMargin, int8_t, -83, -200, 0, 10)                \
+    TUNABLE(nmpMarginFactor, uint8_t, 19, 0, 100, 5)                \
+    TUNABLE(nmpReductionBase, uint8_t, 6, 1, 12, 1)                 \
     TUNABLE(nmpReductionFactor, uint8_t, 4, 1, 12, 1)               \
-    TUNABLE(iirDepthLimit, uint8_t, 3, 2, 12, 1)                    \
-    TUNABLE(lmpDepthLimit, uint8_t, 11, 1, 15, 1)                   \
-    TUNABLE(lmpBase, uint64_t, 9, 0, 15, 1)                         \
-    TUNABLE(lmpMargin, uint64_t, 3, 1, 10, 1)                       \
-    TUNABLE(lmpImproving, uint64_t, 1, 0, 5, 1)                     \
-    TUNABLE(seeQuietMargin, uint8_t, 65, 0, 200, 10)                \
-    TUNABLE(seeNoisyMargin, uint8_t, 25, 0, 100, 5)                 \
+    TUNABLE(iirDepthLimit, uint8_t, 2, 2, 12, 1)                    \
+    TUNABLE(lmpDepthLimit, uint8_t, 10, 1, 15, 1)                   \
+    TUNABLE(lmpBase, uint64_t, 11, 0, 15, 1)                        \
+    TUNABLE(lmpMargin, uint64_t, 2, 1, 10, 1)                       \
+    TUNABLE(lmpImproving, uint64_t, 2, 0, 5, 1)                     \
+    TUNABLE(seeQuietMargin, uint8_t, 64, 0, 200, 10)                \
+    TUNABLE(seeNoisyMargin, uint8_t, 24, 0, 100, 5)                 \
     TUNABLE(seeDepthLimit, uint8_t, 10, 0, 15, 1)                   \
-    TUNABLE(aspirationWindow, uint8_t, 60, 10, 100, 5)              \
-    TUNABLE(pawnCorrectionWeight, uint16_t, 268, 100, 500, 25)      \
-    TUNABLE(materialCorrectionWeight, uint16_t, 884, 500, 1500, 50) \
-    TUNABLE(threatCorrectionWeight, uint16_t, 521, 250, 1000, 25)   \
-    TUNABLE(timeManIncFrac, uint16_t, 89, 1, 150, 5)                \
-    TUNABLE(timeManBaseFrac, uint16_t, 53, 1, 150, 5)               \
-    TUNABLE(timeManLimitFrac, uint16_t, 82, 1, 150, 5)              \
-    TUNABLE(timeManSoftFrac, uint16_t, 49, 1, 150, 5)               \
-    TUNABLE(timeManHardFrac, uint16_t, 331, 100, 500, 20)           \
+    TUNABLE(aspirationWindow, uint8_t, 73, 10, 100, 5)              \
+    TUNABLE(pawnCorrectionWeight, uint16_t, 341, 100, 500, 25)      \
+    TUNABLE(materialCorrectionWeight, uint16_t, 548, 500, 1500, 50) \
+    TUNABLE(threatCorrectionWeight, uint16_t, 545, 250, 1000, 25)   \
+    TUNABLE(timeManIncFrac, uint16_t, 105, 1, 150, 5)               \
+    TUNABLE(timeManBaseFrac, uint16_t, 47, 1, 150, 5)               \
+    TUNABLE(timeManLimitFrac, uint16_t, 78, 1, 150, 5)              \
+    TUNABLE(timeManSoftFrac, uint16_t, 56, 1, 150, 5)               \
+    TUNABLE(timeManHardFrac, uint16_t, 436, 100, 500, 20)           \
     TUNABLE(timeManNodeFracBase, uint8_t, 146, 1, 200, 10)          \
-    TUNABLE(timeManNodeFracMultiplier, uint8_t, 200, 1, 200, 10)    \
+    TUNABLE(timeManNodeFracMultiplier, uint8_t, 169, 1, 200, 10)    \
     TUNABLE(timeManScoreMargin, uint8_t, 9, 1, 20, 1)               \
-    TUNABLE(seePawnValue, int32_t, 100, 50, 200, 5)                 \
-    TUNABLE(seeKnightValue, int32_t, 300, 200, 500, 10)             \
-    TUNABLE(seeBishopValue, int32_t, 300, 200, 500, 10)             \
-    TUNABLE(seeRookValue, int32_t, 500, 350, 750, 10)               \
-    TUNABLE(seeQueenValue, int32_t, 900, 750, 1150, 10)
+    TUNABLE(seePawnValue, int32_t, 110, 50, 200, 5)                 \
+    TUNABLE(seeKnightValue, int32_t, 292, 200, 500, 10)             \
+    TUNABLE(seeBishopValue, int32_t, 306, 200, 500, 10)             \
+    TUNABLE(seeRookValue, int32_t, 509, 350, 750, 10)               \
+    TUNABLE(seeQueenValue, int32_t, 862, 750, 1150, 10)
 
 #ifdef SPSA
 


### PR DESCRIPTION
Apply spsa tuning from:
https://openbench.bunny.beer/tune/621/

Bench 813471

```
Elo   | 35.25 +- 11.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1454 W: 427 L: 280 D: 747
Penta | [21, 134, 309, 203, 60]
https://openbench.bunny.beer/test/625/
```