### PR TITLE
static_evaluation: add endgame scaling

### DIFF
--- a/src/evaluation/term_score.h
+++ b/src/evaluation/term_score.h
@@ -6,6 +6,24 @@
 
 namespace evaluation {
 
+/*
+ * these values seem pretty standard for a few engines out there
+ * borrow them for now and consider if they should be tunable (probably not)
+ *
+ * NOTE: SCB -> Single Color Bishop
+ */
+enum ScaleFactor : uint8_t {
+    Draw = 0,
+    PawnBonus = 8,
+    ScbBishopsOnly = 64,
+    ScbOneKnight = 106,
+    ScbOneRook = 96,
+    LoneQueen = 88,
+    BaseScale = 96,
+    Normal = 128,
+    LargePawnAdv = 144,
+};
+
 struct TermScore {
     uint32_t value;
 
@@ -29,9 +47,16 @@ struct TermScore {
         return static_cast<int16_t>(value >> 16);
     }
 
+    [[nodiscard]] constexpr Score phaseScore(uint8_t phase, uint8_t egFactor) const
+    {
+        return ((this->mg() * phase)
+                   + (this->eg() * (s_middleGamePhase - phase) * egFactor / ScaleFactor::Normal))
+            / s_middleGamePhase;
+    }
+
     [[nodiscard]] constexpr Score phaseScore(uint8_t phase) const
     {
-        return ((this->mg() * phase) + (this->eg() * (s_middleGamePhase - phase))) / s_middleGamePhase;
+        return phaseScore(phase, ScaleFactor::Normal);
     }
 
     constexpr TermScore& operator+=(const TermScore& other) noexcept


### PR DESCRIPTION
Meltdown has always had an issue with endgame evaluation. Often engines would flag a position as drawn quite early while Meltdown would still believe that it was a winnable position.

This commit adds piece endgame awareness to our static evaluation. I've ran a few drawn positions where "old Meltdown" would believe they were clearly winning. Now we know that they're clearly drawn.

Also we apply bonus / penalty based on positions that are often won / lost based on remaining material. This is better than simple piece evaluation as we're now context aware as well!

Bench 809831

```
Endgame book:
Elo   | 22.22 +- 8.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1754 W: 421 L: 309 D: 1024
Penta | [9, 134, 474, 256, 4]
https://openbench.bunny.beer/test/631/

8 moves:
Elo   | 11.83 +- 6.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4760 W: 1153 L: 991 D: 2616
Penta | [118, 503, 989, 639, 131]
https://openbench.bunny.beer/test/632/
```