### PR TITLE
git: add 'subprojects' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 compile_commands.json
 .release
+subprojects
 
 # meson builds are automatically ignored - no need to add them here


### PR DESCRIPTION
Not all versions of meson adds this automatically. So ensure we handle that.

Bench 836728