### PR TITLE
evaluator: modernize iterative deepening

### DIFF
--- a/src/core/board_defs.h
+++ b/src/core/board_defs.h
@@ -127,10 +127,12 @@ enum Phases : uint8_t {
     GamePhaseEg,
 };
 
+// clang-format off
 constexpr static inline std::array<uint8_t, s_amountPieces> s_piecePhaseValues {
     0, 1, 1, 2, 4, 0, /* white */
     0, 1, 1, 2, 4, 0, /* black */
 };
+// clang-format on
 
 constexpr static inline uint8_t s_maxSearchDepth { 128 };
 constexpr static inline uint8_t s_amountSquares { 64 };

--- a/src/spsa/parameters.h
+++ b/src/spsa/parameters.h
@@ -47,6 +47,8 @@
     TUNABLE(seeNoisyMargin, uint8_t, 18, 0, 100, 5)                 \
     TUNABLE(seeDepthLimit, uint8_t, 10, 0, 15, 1)                   \
     TUNABLE(aspirationWindow, uint8_t, 81, 10, 100, 5)              \
+    TUNABLE(aspirationMinDepth, uint8_t, 4, 1, 10, 1)               \
+    TUNABLE(aspirationMaxWindow, uint16_t, 500, 200, 1000, 50)      \
     TUNABLE(pawnCorrectionWeight, uint16_t, 404, 100, 500, 25)      \
     TUNABLE(materialCorrectionWeight, uint16_t, 526, 500, 1500, 50) \
     TUNABLE(threatCorrectionWeight, uint16_t, 580, 250, 1000, 25)   \


### PR DESCRIPTION
```
Elo   | 12.04 +- 6.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4792 W: 1218 L: 1052 D: 2522
Penta | [113, 552, 948, 622, 161]
https://openbench.hans.ovh/test/662/

Elo   | 4.68 +- 3.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13350 W: 2648 L: 2468 D: 8234
Penta | [208, 1439, 3226, 1569, 233]
https://openbench.hans.ovh/test/659/

[still running]
Elo   | 0.11 +- 7.74 (95%)
SPRT  | 5.0+0.05s Threads=4 Hash=64MB
LLR   | 0.06 (-2.94, 2.94) [-2.00, 0.00]
Games | N: 3104 W: 636 L: 635 D: 1833
Penta | [63, 369, 686, 372, 62]
https://openbench.hans.ovh/test/661/
```